### PR TITLE
Initial proposal for hlsl::numeric_limits

### DIFF
--- a/proposals/0003-numeric-constants.md
+++ b/proposals/0003-numeric-constants.md
@@ -30,10 +30,15 @@ the proposed interface for the `hlsl::numeric_limits` class:
   public:
     static Ty min();
     static Ty max();
+    static Ty lowest();
+    static Ty denorm_min();
 
     // Implement infinity in terms of __builtin_huge_val
     static Ty infinity();
     static Ty negative_infinity();
+
+    static Ty quiet_NaN();
+    static Ty signaling_NaN();
   }
 ```
 


### PR DESCRIPTION
This seeks to remove the HLSL `#INF` syntax in favor of a more C++-like hlsl::numeric_limits construct.