### PR TITLE
Initial HLSL Specifiction LaTeX stub

### DIFF
--- a/specs/language/CMakeLists.txt
+++ b/specs/language/CMakeLists.txt
@@ -1,0 +1,45 @@
+project(hlsl NONE)
+cmake_minimum_required(VERSION 3.15)
+
+find_package(LATEX REQUIRED COMPONENTS)
+
+if (NOT MAKEGLOSSARIES_COMPILER)
+  get_filename_component(LATEX_DIR ${PDFLATEX_COMPILER} DIRECTORY)
+  find_program(MAKEGLOSSARIES_COMPILER makeglossaries HINTS ${LATEX_DIR})
+endif()
+
+if (NOT MAKEGLOSSARIES_COMPILER)
+  message(FATAL_ERROR "Could not find makeglossaries")
+endif()
+
+set(intermediate_dir ${CMAKE_BINARY_DIR}/tmp/)
+
+message(STATUS "Generating targets for: ${PROJECT_NAME}")
+set(main_file ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.tex)
+set(out_dir ${CMAKE_BINARY_DIR})
+
+add_custom_target(${PROJECT_NAME}-dirs
+                  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}
+                  COMMENT "Creating directories for ${PROJECT_NAME}")
+
+add_custom_target(${PROJECT_NAME}-prebuild
+                  COMMAND ${PDFLATEX_COMPILER}
+                            -output-directory ${CMAKE_BINARY_DIR}
+                            -draftmode -interaction=nonstopmode
+                            ${main_file}
+                  COMMENT "Prebuilding ${PROJECT_NAME}"
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  DEPENDS ${main_file} ${PROJECT_NAME}-dirs)
+add_custom_target(${PROJECT_NAME}-glossaries
+                COMMAND ${MAKEGLOSSARIES_COMPILER} -d ${CMAKE_BINARY_DIR} ${PROJECT_NAME}
+                COMMENT "Prebuilding ${PROJECT_NAME} Glossaries"
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                DEPENDS ${main_file} ${PROJECT_NAME}-prebuild)
+add_custom_target(pdf
+                  COMMAND ${PDFLATEX_COMPILER}
+                          -output-directory ${CMAKE_BINARY_DIR}
+                          ${main_file}
+                  COMMENT "Assembling ${PROJECT_NAME}.pdf"
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  DEPENDS ${main_file} ${PROJECT_NAME}-prebuild ${PROJECT_NAME}-glossaries)
+

--- a/specs/language/glossary.tex
+++ b/specs/language/glossary.tex
@@ -1,0 +1,83 @@
+\makeglossaries
+
+\newacronym{hlsl}{HLSL}{High Level Shader Language}
+\newacronym{dxc}{DXC}{DirectX Shader Compiler}
+\newacronym{fxc}{FXC}{Legacy DirectX Shader Compiler}
+\newacronym{c}{C}{C Programming Language}
+\newacronym{cpp}{C++}{C++ Programming Language}
+\newacronym{api}{API}{Application Programming Interface}
+\newacronym{spmd}{SPMD}{Single Program Multiple Data}
+\newacronym{simd}{SIMD}{Single Instruction Multiple Data}
+\newacronym{glsl}{GLSL}{OpenGL Shading Language}
+
+\newglossaryentry{spirv}
+{
+  name={SPIR-V},
+  description={SPIR-V is a portable intermediate representation designed by the
+  Khronos Group for representing GPU programs}
+}
+
+\newglossaryentry{dx}
+{
+  name={DirectX},
+  description={DirectX is the multimedia \acrshort{api} introduced with Windows
+  95.}
+}
+
+\newglossaryentry{isoC}
+{
+  name={ISO/IEC 9899:2018},
+  description={ISO C standard}
+}
+
+\newglossaryentry{isoCPP}
+{
+  name={ISO/IEC 14882:2020},
+  description={ISO C++ standard}
+}
+
+\newglossaryentry{sm}
+{
+  name={Shader Model},
+  description={Versioned hardware description included as part of the DirectX
+  specification, which is used for code generation of GPU code to a common set
+  of features across a range of vendors.}
+}
+
+\newglossaryentry{lane}{
+  name={Lane},
+  description={The computation performed on a single element as described in the
+  \acrshort{spmd} program. Also called: thread.}
+}
+
+\newglossaryentry{wave}{
+  name={Wave},
+  description={A group of \gls{lane}s which execute together. The number of
+  \gls{lane}s in a Wave varies by hardware implementation. Also called: warp,
+  SIMD-group, subgroup, or wavefront.}
+}
+
+\newglossaryentry{quad}{
+  name={Quad},
+  description={A group of four \gls{lane}s which form a cluster of adjacent
+  computations in the data topology. Also called: quad-group or quad-wave. }
+}
+
+\newglossaryentry{threadgroup}{
+  name={Thread Group},
+  description={A group of one or more \gls{wave}s which comprise a larger
+  computation. Also known as: group, workgroup, block or thread block.}
+}
+
+\newglossaryentry{dispatch}{
+  name={Dispatch},
+  description={A group of one or more \gls{threadgroup}s which comprise the
+  largest unit of a shader execution. Also called: grid, compute space or index
+  space.}
+}
+
+\newglossaryentry{oglsl}{
+  name={\acrfull{glsl}},
+  description={OpenGL Shading Language introduced as an extension to OpenGL 1.4
+  and as a full feature in OpenGL 2.0.}
+}

--- a/specs/language/glossary.tex
+++ b/specs/language/glossary.tex
@@ -8,7 +8,6 @@
 \newacronym{api}{API}{Application Programming Interface}
 \newacronym{spmd}{SPMD}{Single Program Multiple Data}
 \newacronym{simd}{SIMD}{Single Instruction Multiple Data}
-\newacronym{glsl}{GLSL}{OpenGL Shading Language}
 
 \newglossaryentry{spirv}
 {
@@ -74,10 +73,4 @@
   description={A group of one or more \gls{threadgroup}s which comprise the
   largest unit of a shader execution. Also called: grid, compute space or index
   space.}
-}
-
-\newglossaryentry{oglsl}{
-  name={\acrfull{glsl}},
-  description={OpenGL Shading Language introduced as an extension to OpenGL 1.4
-  and as a full feature in OpenGL 2.0.}
 }

--- a/specs/language/hlsl.tex
+++ b/specs/language/hlsl.tex
@@ -15,6 +15,10 @@
 
 \renewcommand{\familydefault}{\sfdefault}
 
+\newcommand{\Ch}[2]{\chapter[#1]{#1\hfill[#2]}\label{#2}}
+\newcommand{\Sec}[2]{\section[#1]{#1\hfill[#2]}\label{#2}}
+\newcommand{\Sub}[2]{\subsection[#1]{#1\hfill[#2]}\label{#2}}
+
 \input{glossary}
 
 \title{High-Level Shader Language Specification\\

--- a/specs/language/hlsl.tex
+++ b/specs/language/hlsl.tex
@@ -1,0 +1,70 @@
+\documentclass[oneside]{book}
+\usepackage[utf8]{inputenc}
+\usepackage[english]{babel}
+\usepackage[acronym]{glossaries}
+\usepackage{multicol}
+\usepackage[marginparwidth=75pt, margin=2cm]{geometry}
+\usepackage{listings}
+\usepackage{marginnote}
+\usepackage{parskip}
+\usepackage{titlesec}
+
+\titleformat{\chapter}
+  {\LARGE\bfseries}{\thechapter}{10pt}{}
+\titlespacing{\chapter}{0pt}{0pt}{10pt}
+
+\renewcommand{\familydefault}{\sfdefault}
+
+\input{glossary}
+
+\title{High-Level Shader Language Specification\\
+       \normalsize{Working Draft}}
+
+
+\newenvironment{note}
+    {\begin{center}
+    \begin{tabular}{|p{0.9\textwidth}|}
+    \hline\\ 
+    }
+    { 
+    \\\\\hline
+    \end{tabular} 
+    \end{center}
+    }
+
+\usepackage{titleps}
+\newpagestyle{body}{
+  \sethead{}{}{\sectiontitle}
+  \setfoot{}{}{Working Draft}
+}
+\pagestyle{body}
+
+\newcommand{\parnum}{\textbf{\arabic{parcount}}}
+
+\setlength\parindent{0cm}
+
+\newcounter{parcount}
+\counterwithin{parcount}{subsection}
+\newcommand\p{%
+    \stepcounter{parcount}%
+    \parnum \hspace{1em}%
+}
+
+\newenvironment{parnumbers}{%
+   \par%
+   \everypar{\noindent \stepcounter{parcount}\parnum \hspace{1em}}%
+}{}
+
+\begin{document}
+\maketitle
+
+\tableofcontents
+\input{introduction}
+
+\clearpage
+
+\label{glossaries}
+\printglossary[type=\acronymtype]
+\printglossary
+
+\end{document}

--- a/specs/language/introduction.tex
+++ b/specs/language/introduction.tex
@@ -1,4 +1,4 @@
-\chapter{Introduction} \label{ch:Intro}
+\Ch{Introduction}{Intro}
 
 \p The \acrfull{hlsl} is the GPU programming language provided in conjunction
 with the \gls{dx} runtime. Over many years its use has expanded to cover every
@@ -26,7 +26,7 @@ where there is an intent to alter implementation behavior in the future. Since
 this document and the implementations are living sources, one or the other may
 be ahead in different regards at any point in time.
 
-\section{Scope} \label{sec:Scope}
+\Sec{Scope}{Intro.Scope}
 
 \p This document specifies the requirements for implementations of
 \acrshort{hlsl}. The \acrshort{hlsl} specification is based on and highly
@@ -36,7 +36,7 @@ influenced by the specifications for the \acrfull{c} and the \acrfull{cpp}.
 \acrshort{hlsl}, and (in later sections) the standard library of data types used
 in shader programming.
 
-\section{Normative References} \label{sec:Refs}
+\Sec{Normative References}{Intro.Refs}
 
 \p The following referenced documents provide significant influence on this
 document and should be used in conjunction with interpreting this standard.
@@ -47,14 +47,14 @@ document and should be used in conjunction with interpreting this standard.
   \item \gls{dx} Specifications, \textit{https://microsoft.github.io/DirectX-Specs/}
 \end{itemize}
 
-\section{Terms and definitions} \label{sec:Terms}
+\Sec{Terms and definitions}{Intro.Terms}
 
 \p This document aims to use terms consistent with their definitions in
 \gls{isoC} and \gls{isoCPP}. In cases where the definitions are unclear, or
 where this document diverges this section, the remaining sections in this
 chapter, and the attached \ref{glossaries}.
 
-\section{Runtime Targeting} \label{sec:Runtime}
+\Sec{Runtime Targeting}{Intro.Runtime}
 
 \p \acrshort{hlsl} evolved out of \gls{dx} and gained popularity because it
 targeted a common hardware description which all conforming drivers were
@@ -63,7 +63,7 @@ integral part of the description for \acrshort{hlsl} . Some \acrshort{hlsl}
 features require specific \gls{sm} features, and are only supported by compilers
 when targeting those \gls{sm} versions or later.
 
-\section{\acrfull{spmd} Programming Model} \label{sec:Model}
+\Sec{\acrfull{spmd} Programming Model}{Intro.Model}
 
 \p \acrshort{hlsl} uses a \acrfull{spmd} programming model where a program
 describes operations on a single element of data, but when the program executes
@@ -76,7 +76,7 @@ time.
 architecture and the way they relate to the \acrshort{spmd} program model. In
 this document we will use the terms as defined in the following subsections.
 
-\subsection{\gls{lane}} \label{subsection:Lane}
+\Sub{\gls{lane}}{Intro.Model.Lane}
 
 \p A \gls{lane} represents a single computed element in an \acrshort{spmd}
 program. In a traditional programming model it would be analogous to a thread of
@@ -86,7 +86,7 @@ of \gls{lane}s execute instructions in lock step because each instruction is a
 \acrshort{simd} instruction computing the results for multiple \gls{lane}s
 simultaneously.
 
-\subsection{\gls{wave}} \label{subsection:Wave}
+\Sub{\gls{wave}}{Intro.Model.Wave}
 
 \p A grouping of \gls{lane}s for execution is called a \gls{wave}. \gls{wave}
 sizes vary by hardware architecture. Some hardware implementations support
@@ -94,7 +94,7 @@ multiple wave sizes. Generally wave sizes are powers of two, but there is no
 requirement that be the case. \acrshort{hlsl} is explicitly designed to run on
 hardware with arbitrary \gls{wave} sizes.
 
-\subsection{\gls{quad}} \label{subsection:Quad}
+\Sub{\gls{quad}}{Intro.Model.Quad}
 
 \p A \gls{quad} is a subdivision of four \gls{lane}s in a \gls{wave} which are
 computing adjacent values. In pixel shaders a \gls{quad} may represent four
@@ -103,20 +103,20 @@ lanes. In compute shaders quads may be one or two dimensional depending on the
 workload dimensionality described in the \texttt{numthreads} attribute on the
 entry function. (FIXME: Add reference to attribute)
 
-\subsection{\gls{threadgroup}} \label{subsection:Group}
+\Sub{\gls{threadgroup}}{Intro.Model.Group}
 
 \p A grouping of \gls{wave}s executing the same shader to produce a combined
 result is called a \gls{threadgroup}. \gls{threadgroup}s are executed on
 separate \acrshort{simd} hardware and are not instruction locked with other
 \gls{threadgroup}s.
 
-\subsection{\gls{dispatch}} \label{subsection:Dispatch}
+\Sub{\gls{dispatch}}{Intro.Model.Dispatch}
 
 \p A grouping of \gls{threadgroup}s which represents the full execution of a
 \acrshort{hlsl} program and results in a completed result for all input data
 elements.
 
-\section{\acrshort{hlsl} Memory Models} \label{sec:Memory}
+\Sec{\acrshort{hlsl} Memory Models}{Intro.Memory}
 
 \p Memory accesses for \gls{sm} 5.0 and earlier operate on 128-bit slots aligned
 on 128-bit boundaries. This optimized for the common case in early shaders where
@@ -129,37 +129,37 @@ multiples are supported with \gls{sm} 6.0. \gls{sm} features are fully
 documented in the \gls{dx} Specifications, and this document will not attempt to
 elaborate further.
 
-\section{Common Definitions} \label{sec:Definitions}
+\Sec{Common Definitions}{Intro.Defs}
 
 \p The following definitions are consistent between \acrshort{hlsl} and the
 \gls{isoC} and \gls{isoCPP} specifications, however they are included here for
 reader convenience.
 
-\subsection{Diagnostic Message}
+\Sub{Diagnostic Message}{Intro.Defs.Diags}
 \p An implementation defined message belonging to a subset of the
 implementation's output messages which communicates diagnostic information to
 the user.
 
-\subsection{Ill-formed Program}
+\Sub{Ill-formed Program}{Intro.Defs.IllFormed}
 \p A program that is not well formed, for which the implementation is expected
 to return unsuccessfully and produce one or more diagnostic messages.
 
-\subsection{Implementation-defined Behavior}
+\Sub{Implementation-defined Behavior}{Intro.Defs.ImpDef}
 \p Behavior of a well formed program and correct data which may vary by the
 implementation, and the implementation is expected to document the behavior.
 
-\subsection{Implementation Limits}
+\Sub{Implementation Limits}{Intro.Defs.ImpLimits}
 \p Restrictions imposed upon programs by the implementation.
 
-\subsection{Undefined Behavior}
+\Sub{Undefined Behavior}{Intro.Defs.Undefined}
 
 \p Behavior of invalid program constructs or incorrect data which this standard
 imposes no requirements, or does not sufficiently detail.
 
-\subsection{Unspecified Behavior}
+\Sub{Unspecified Behavior}{Intro.Defs.Unspecified}
 \p Behavior of a well formed program and correct data which may vary by the
 implementation, and the implementation is not expected to document the behavior.
 
-\subsection{Well-formed Program}
+\Sub{Well-formed Program}{Intro.Defs.WellFormed}
 \p An HLSL program constructed according to the syntax rules, diagnosable
 semantic rules, and the One Definition Rule.

--- a/specs/language/introduction.tex
+++ b/specs/language/introduction.tex
@@ -6,6 +6,11 @@ major rendering API across all major development platforms. Despite its
 popularity and long history \acrshort{hlsl} has never had a formal language
 specification. This document seeks to change that.
 
+\p \acrshort{hlsl} draws heavy inspiration originally from \gls{isoC} and later
+from \gls{isoCPP} with additions specific to graphics and parallel computation
+programming. The language is also influenced to a lesser degree by other popular
+graphics and parallel programming languages.
+
 \p \acrshort{hlsl} has two reference implementations which this specification
 draws heavily from. The original reference implementation \acrfull{fxc} has been
 in use since \gls{dx} 9. The more recent reference implementation \acrfull{dxc}
@@ -15,9 +20,11 @@ has been the primary shader compiler since \gls{dx} 12.
 behavior of \acrshort{dxc} rather than the behavior of \acrshort{fxc}, although
 that can vary by context.
 
-\p In places this spec will be aspirational, and diverge from both reference
-implementation behaviors. In particular in cases where the two implementations
-disagree the spec written may choose a third option.
+\p In very rare instances this spec will be aspirational, and may diverge from
+both reference implementation behaviors. This will only be done in instances
+where there is an intent to alter implementation behavior in the future. Since
+this document and the implementations are living sources, one or the other may
+be ahead in different regards at any point in time.
 
 \section{Scope} \label{sec:Scope}
 
@@ -38,7 +45,6 @@ document and should be used in conjunction with interpreting this standard.
   \item \gls{isoC}, \textit{Programming languages - C}
   \item \gls{isoCPP}, \textit{Programming languages - C++}
   \item \gls{dx} Specifications, \textit{https://microsoft.github.io/DirectX-Specs/}
-  \item \gls{oglsl} Specification, \textit{https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.pdf}
 \end{itemize}
 
 \section{Terms and definitions} \label{sec:Terms}

--- a/specs/language/introduction.tex
+++ b/specs/language/introduction.tex
@@ -1,0 +1,159 @@
+\chapter{Introduction} \label{ch:Intro}
+
+\p The \acrfull{hlsl} is the GPU programming language provided in conjunction
+with the \gls{dx} runtime. Over many years its use has expanded to cover every
+major rendering API across all major development platforms. Despite its
+popularity and long history \acrshort{hlsl} has never had a formal language
+specification. This document seeks to change that.
+
+\p \acrshort{hlsl} has two reference implementations which this specification
+draws heavily from. The original reference implementation \acrfull{fxc} has been
+in use since \gls{dx} 9. The more recent reference implementation \acrfull{dxc}
+has been the primary shader compiler since \gls{dx} 12.
+
+\p In writing this specification bias is leaned toward the language
+behavior of \acrshort{dxc} rather than the behavior of \acrshort{fxc}, although
+that can vary by context.
+
+\p In places this spec will be aspirational, and diverge from both reference
+implementation behaviors. In particular in cases where the two implementations
+disagree the spec written may choose a third option.
+
+\section{Scope} \label{sec:Scope}
+
+\p This document specifies the requirements for implementations of
+\acrshort{hlsl}. The \acrshort{hlsl} specification is based on and highly
+influenced by the specifications for the \acrfull{c} and the \acrfull{cpp}.
+
+\p This document covers both describing the language grammar and semantics for
+\acrshort{hlsl}, and (in later sections) the standard library of data types used
+in shader programming.
+
+\section{Normative References} \label{sec:Refs}
+
+\p The following referenced documents provide significant influence on this
+document and should be used in conjunction with interpreting this standard.
+
+\begin{itemize}
+  \item \gls{isoC}, \textit{Programming languages - C}
+  \item \gls{isoCPP}, \textit{Programming languages - C++}
+  \item \gls{dx} Specifications, \textit{https://microsoft.github.io/DirectX-Specs/}
+  \item \gls{oglsl} Specification, \textit{https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.pdf}
+\end{itemize}
+
+\section{Terms and definitions} \label{sec:Terms}
+
+\p This document aims to use terms consistent with their definitions in
+\gls{isoC} and \gls{isoCPP}. In cases where the definitions are unclear, or
+where this document diverges this section, the remaining sections in this
+chapter, and the attached \ref{glossaries}.
+
+\section{Runtime Targeting} \label{sec:Runtime}
+
+\p \acrshort{hlsl} evolved out of \gls{dx} and gained popularity because it
+targeted a common hardware description which all conforming drivers were
+required to support. This common hardware description, called a \gls{sm}, is an
+integral part of the description for \acrshort{hlsl} . Some \acrshort{hlsl}
+features require specific \gls{sm} features, and are only supported by compilers
+when targeting those \gls{sm} versions or later.
+
+\section{\acrfull{spmd} Programming Model} \label{sec:Model}
+
+\p \acrshort{hlsl} uses a \acrfull{spmd} programming model where a program
+describes operations on a single element of data, but when the program executes
+it executes across more than one element at a time. This programming model is
+useful due to GPUs largely being \acrfull{simd} hardware architectures where
+each instruction natively executes across multiple data elements at the same
+time.
+
+\p There are many different terms of art for describing the elements of a GPU
+architecture and the way they relate to the \acrshort{spmd} program model. In
+this document we will use the terms as defined in the following subsections.
+
+\subsection{\gls{lane}} \label{subsection:Lane}
+
+\p A \gls{lane} represents a single computed element in an \acrshort{spmd}
+program. In a traditional programming model it would be analogous to a thread of
+execution, however it differs in one key way. In multi-threaded programming
+threads advance independent of each other. In \acrshort{spmd} programs, a group
+of \gls{lane}s execute instructions in lock step because each instruction is a
+\acrshort{simd} instruction computing the results for multiple \gls{lane}s
+simultaneously.
+
+\subsection{\gls{wave}} \label{subsection:Wave}
+
+\p A grouping of \gls{lane}s for execution is called a \gls{wave}. \gls{wave}
+sizes vary by hardware architecture. Some hardware implementations support
+multiple wave sizes. Generally wave sizes are powers of two, but there is no
+requirement that be the case. \acrshort{hlsl} is explicitly designed to run on
+hardware with arbitrary \gls{wave} sizes.
+
+\subsection{\gls{quad}} \label{subsection:Quad}
+
+\p A \gls{quad} is a subdivision of four \gls{lane}s in a \gls{wave} which are
+computing adjacent values. In pixel shaders a \gls{quad} may represent four
+adjacent pixels and \gls{quad} operations allow passing data between adjacent
+lanes. In compute shaders quads may be one or two dimensional depending on the
+workload dimensionality described in the \texttt{numthreads} attribute on the
+entry function. (FIXME: Add reference to attribute)
+
+\subsection{\gls{threadgroup}} \label{subsection:Group}
+
+\p A grouping of \gls{wave}s executing the same shader to produce a combined
+result is called a \gls{threadgroup}. \gls{threadgroup}s are executed on
+separate \acrshort{simd} hardware and are not instruction locked with other
+\gls{threadgroup}s.
+
+\subsection{\gls{dispatch}} \label{subsection:Dispatch}
+
+\p A grouping of \gls{threadgroup}s which represents the full execution of a
+\acrshort{hlsl} program and results in a completed result for all input data
+elements.
+
+\section{\acrshort{hlsl} Memory Models} \label{sec:Memory}
+
+\p Memory accesses for \gls{sm} 5.0 and earlier operate on 128-bit slots aligned
+on 128-bit boundaries. This optimized for the common case in early shaders where
+data being processed on the GPU was usually 4-element vectors of 32-bit data
+types.
+
+\p On modern hardware memory access restrictions are loosened, and reads of
+32-bit multiples are supported starting with \gls{sm} 5.1 and reads of 16-bit
+multiples are supported with \gls{sm} 6.0. \gls{sm} features are fully
+documented in the \gls{dx} Specifications, and this document will not attempt to
+elaborate further.
+
+\section{Common Definitions} \label{sec:Definitions}
+
+\p The following definitions are consistent between \acrshort{hlsl} and the
+\gls{isoC} and \gls{isoCPP} specifications, however they are included here for
+reader convenience.
+
+\subsection{Diagnostic Message}
+\p An implementation defined message belonging to a subset of the
+implementation's output messages which communicates diagnostic information to
+the user.
+
+\subsection{Ill-formed Program}
+\p A program that is not well formed, for which the implementation is expected
+to return unsuccessfully and produce one or more diagnostic messages.
+
+\subsection{Implementation-defined Behavior}
+\p Behavior of a well formed program and correct data which may vary by the
+implementation, and the implementation is expected to document the behavior.
+
+\subsection{Implementation Limits}
+\p Restrictions imposed upon programs by the implementation.
+
+\subsection{Undefined Behavior}
+
+\p Behavior of invalid program constructs or incorrect data which this standard
+imposes no requirements, or does not sufficiently detail.
+
+\subsection{Unspecified Behavior}
+\p Behavior of a well formed program and correct data which may vary by the
+implementation, and the implementation is not expected to document the behavior.
+
+\subsection{Well-formed Program}
+\p An HLSL program constructed according to the syntax rules, diagnosable
+semantic rules, and the One Definition Rule.


### PR DESCRIPTION
This stubs out some LaTeX goop and a first stab at the Introduction for an HLSL Specification.

I'm sure LaTeX isn't everyone's preferred format, but it is git-friendly and supports all the formatting bells and whistles we might need.