### PR TITLE
[0007] Big update to flesh out const instance methods

### DIFF
--- a/proposals/0007-const-instance-methods.md
+++ b/proposals/0007-const-instance-methods.md
@@ -1,3 +1,4 @@
+<!-- {% raw %} -->
 # `const`-qualified Instance Methods
 
 * Proposal: [0007](0007-const-instance-methods.md)
@@ -148,3 +149,5 @@ overload resolution and standard argument conversions.
 This change should have no impact on code generation through SPIR-V or DXIL
 assuming that the existing parameter mangling for constant implicit object
 parameters works as expected.
+
+<!-- {% endraw %} -->

--- a/proposals/0007-const-member-functions.md
+++ b/proposals/0007-const-member-functions.md
@@ -5,7 +5,7 @@
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: TBD
 * Status: **Under Consideration**
-* Planned Version: 202x
+* Planned Version: 202y
 
 ## Introduction
 


### PR DESCRIPTION
I started digging a bit into this in DXC and identified a lot of cross-cutting issues that we need to consider in this.

This change updates the proposal to flesh out the behavior and related issues around HLSL const-correctness.

This does identify some source-breaking changes that this would introduce as well as some behavior changes that I think we should introduce in the HLSL built-in types.