### PR TITLE
Add new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Which proposal does this relate to?**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Please link the file in the repo where the problem is documented.
 
 **Describe the issue or outstanding question.**
 This can be as short as a question that needs answering or as complex as needed

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,18 @@
+---
+name: Proposal Follow-up
+about: Follow-up issue for a proposal
+title: ''
+labels: 'active proposal'
+assignees: ''
+
+---
+
+**Which proposal does this relate to?**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the issue or outstanding question.**
+This can be as short as a question that needs answering or as complex as needed
+to convey the problem that needs solving.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**Which spec or proposal does this relate to?**
+**Which document does this relate to?**
 Please link the file in the repo where the problem is documented.
 
 **Describe the issue you see with the spec**

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -1,6 +1,6 @@
 ---
 name: Spec
-about: Highlight a problem with a published or adopted spec
+about: Highlight a problem with a published spec or accepted proposal
 title: ''
 labels: 'spec'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -1,5 +1,5 @@
 ---
-name: Spec Issue
+name: Spec
 about: Highlight a problem with a published or adopted spec
 title: ''
 labels: 'spec'
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Which spec or proposal does this relate to?**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Please link the file in the repo where the problem is documented.
 
 **Describe the issue you see with the spec**
 A clear and concise description of the problem.

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -1,0 +1,17 @@
+---
+name: Spec Issue
+about: Highlight a problem with a published or adopted spec
+title: ''
+labels: 'spec'
+assignees: ''
+
+---
+
+**Which spec or proposal does this relate to?**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the issue you see with the spec**
+A clear and concise description of the problem.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/docs/Process.md
+++ b/docs/Process.md
@@ -31,10 +31,10 @@ further tweaked to align with the HLSL team's goals and priorities.
 ## Proposing a Feature
 
 By far the best way for an external contributor to propose a feature is through
-GitHub issues. If you can't be deterred from writing a proposal yourself you
-must find a member of the HLSL team to act as a _Sponsor_ for the change. The
-_Sponsor_ is responsible for tracking and helping change proposals through the
-proposal life cycle.
+GitHub issues (See the section below on "Filing Issues"). If you can't be
+deterred from writing a proposal yourself you must find a member of the HLSL
+team to act as a _Sponsor_ for the change. The _Sponsor_ is responsible for
+tracking and helping change proposals through the proposal life cycle.
 
 All feature proposals are evaluated against the goals for the next HLSL language
 revision. The goals for the upcoming HLSL language version can be found
@@ -78,3 +78,21 @@ rationale behind why the feature was rejected.
 deferred may be provided with some justification for the deferral although the
 requirements for justification are not high and could be as simple as
 "insufficient resources".
+
+## Filing Issues
+
+This repository provides three custom issue templates:
+
+1. Feature Request
+2. Proposal
+3. Spec
+
+When filing feature requests please use the _Feature Request_ template. The more
+detailed information you can provide in a feature request the easier it is for
+our team to scope, prioritize, design and implement the requested feature.
+
+When filing issues relating to a currently in-progress proposal (i.e. any proposal not
+**Completed** or **Rejected**), use the _Proposal Follow-up_ template.
+
+When filing issues relating to a completed feature or specification document
+please use the _Spec_ template.


### PR DESCRIPTION
These templates are for helping file spec issues and proposal follow-up issues so that we can better track proposals as they are being developed.