### PR TITLE
Add casting to buffer pointer proposal.

### DIFF
--- a/proposals/0010-vk-buffer-ref.md
+++ b/proposals/0010-vk-buffer-ref.md
@@ -58,7 +58,7 @@ This new type will have the following operations
 * Copy assignment and copy construction - These copy the value of the pointer from one variable to another.
 * Dereference Method - The Get() method represents the struct const lvalue reference of the pointer to which it is applied. The selection . operator can be applied to the Get() to further select a member from the referenced struct.
 * A new cast operator vk::pointer_cast<T,A>(p) is introduced. It creates a value of type BufferPointer<T,A>. The argument p can be of any BufferPointer type or uint64_t.
-* A buffer pointer can be cast to a bool. If so, it returns FALSE if the pointeris null, TRUE otherwise.
+* A buffer pointer can be cast to a bool. If so, it returns FALSE if the pointer is null, TRUE otherwise.
 
 Note the operations that are not allowed:
 

--- a/proposals/0010-vk-buffer-ref.md
+++ b/proposals/0010-vk-buffer-ref.md
@@ -67,7 +67,7 @@ Note the operations that are not allowed:
 * There is no explicit pointer arithmetic. All addressing is implicitly done using the `.` pointer, or indexing an array in the struct T.
 * The comparison operators == and != are not supported for buffer pointers.
 
-Most of these restrictions are there for safety. They minimize the possibility of getting an invalid pointer. If the Get() method is used on a null pointer, the behaviour is undefined.
+Most of these restrictions are there for safety. They minimize the possibility of getting an invalid pointer. If the Get() method is used on a null or an invalid pointer, the behaviour is undefined.
 
 When used as a member in a buffer, vk::BufferPointer can be used to pass physical buffer addresses into a shader, and address and access buffer space with logical addressing, which allows tools such as spirv-opt, spirv-reflect and renderdoc to be able to better work with these shaders.
 

--- a/proposals/0010-vk-buffer-ref.md
+++ b/proposals/0010-vk-buffer-ref.md
@@ -57,9 +57,8 @@ This new type will have the following operations
 
 * Copy assignment and copy construction - These copy the value of the pointer from one variable to another.
 * Dereference Method - The Get() method represents the struct const lvalue reference of the pointer to which it is applied. The selection . operator can be applied to the Get() to further select a member from the referenced struct.
-* A buffer pointer can be cast to a uint64_t using uint64_t(bp). If the buffer pointer is null, the uint64_t is zero.
-* A uint64_t can be cast to a buffer pointer type. The name of the buffer pointer type is used as the casting method. If the uint64_t is zero, the buffer pointer is null. 
-* A buffer pointer can be cast to another buffer pointer type. It is equivalent to casting the buffer pointer to a uint64_t, and then casting the uint64_t to the new buffer pointer type.
+* A new cast operator vk::pointer_cast<T,A>(p) is introduced. It creates a value of type BufferPointer<T,A>. The argument p can be of any BufferPointer type or uint64_t.
+* A buffer pointer can be cast to a bool. If so, it returns FALSE if the pointeris null, TRUE otherwise.
 
 Note the operations that are not allowed:
 
@@ -67,7 +66,7 @@ Note the operations that are not allowed:
 * There is no explicit pointer arithmetic. All addressing is implicitly done using the `.` pointer, or indexing an array in the struct T.
 * The comparison operators == and != are not supported for buffer pointers.
 
-Most of these restrictions are there for safety. They minimize the possibility of getting an invalid pointer. If the Get() method is used on a null or an invalid pointer, the behaviour is undefined.
+Most of these restrictions are there for safety. They minimize the possibility of getting an invalid pointer. If the Get() method is used on a null or invalid pointer, the behaviour is undefined.
 
 When used as a member in a buffer, vk::BufferPointer can be used to pass physical buffer addresses into a shader, and address and access buffer space with logical addressing, which allows tools such as spirv-opt, spirv-reflect and renderdoc to be able to better work with these shaders.
 

--- a/proposals/0010-vk-buffer-ref.md
+++ b/proposals/0010-vk-buffer-ref.md
@@ -57,7 +57,8 @@ This new type will have the following operations
 
 * Copy assignment and copy construction - These copy the value of the pointer from one variable to another.
 * Dereference Method - The Get() method represents the struct const lvalue reference of the pointer to which it is applied. The selection . operator can be applied to the Get() to further select a member from the referenced struct.
-* A new cast operator vk::pointer_cast<T,A>(p) is introduced. It creates a value of type BufferPointer<T,A>. The argument p can be of any BufferPointer type or uint64_t.
+* Two new cast operators are introduced. vk::static_pointer_cast<T, A> allows casting any vk::BufferPointer<SrcType, SrcAlign> to vk::BufferPointer<DstType, DstAlign> only if SrcType is a type derived from DstType. vk::reinterpret_pointer_cast<T, A> allows casting for all other BufferPointer types. For both casts, DstAlign <= SrcAlign must be true. 
+* A buffer pointer can be constructed from a uint64_t u using the constructor syntax vk::BufferPointer<T,A>(u).
 * A buffer pointer can be cast to a bool. If so, it returns FALSE if the pointer is null, TRUE otherwise.
 
 Note the operations that are not allowed:

--- a/proposals/0010-vk-buffer-ref.md
+++ b/proposals/0010-vk-buffer-ref.md
@@ -57,12 +57,13 @@ This new type will have the following operations
 
 * Copy assignment and copy construction - These copy the value of the pointer from one variable to another.
 * Dereference Method - The Get() method represents the struct const lvalue reference of the pointer to which it is applied. The selection . operator can be applied to the Get() to further select a member from the referenced struct.
-* Null Pointer Method - The IsNull() method returns true if the pointer is 0, false if not.
+* A buffer pointer can be cast to a uint64_t using uint64_t(bp). If the buffer pointer is null, the uint64_t is zero.
+* A uint64_t can be cast to a buffer pointer type. The name of the buffer pointer type is used as the casting method. If the uint64_t is zero, the buffer pointer is null. 
+* A buffer pointer can be cast to another buffer pointer type. It is equivalent to casting the buffer pointer to a uint64_t, and then casting the uint64_t to the new buffer pointer type.
 
 Note the operations that are not allowed:
 
 * There is no default construction. Every vk::BufferPointer<T> is either contained in a global resource (like a cbuffer, ubo, or ssbo), or it must be constructed using the copy constructor. 
-* There is no conversion from uint64_t to vk:BufferPointer.
 * There is no explicit pointer arithmetic. All addressing is implicitly done using the `.` pointer, or indexing an array in the struct T.
 * The comparison operators == and != are not supported for buffer pointers.
 


### PR DESCRIPTION
I used the existing HLSL practice of using the new type name as the name of the casting method. I did not add a vk::pointer_cast<>() method. If there is an advantage to such a method, I am open to it.

Fixes #44 