### PR TITLE
Add table of contents sidebar and links to HLSL spec (hyperref)

### DIFF
--- a/specs/language/hlsl.tex
+++ b/specs/language/hlsl.tex
@@ -9,6 +9,7 @@
 \usepackage{parskip}
 \usepackage{titlesec}
 \usepackage{enumitem}
+\usepackage[hidelinks]{hyperref}
 
 \titleformat{\chapter}
   {\LARGE\bfseries}{\thechapter}{10pt}{}


### PR DESCRIPTION
The hyperref package makes table of contents entries clickable, makes the contents sidebar work, and lets `\ref` make clickable links.