### PR TITLE
Manually grab pandoc-3.1.9

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           sudo apt -y install texlive
           sudo apt -y install texlive-latex-extra
-          sudo apt -y install pandoc
+          curl -fsSL https://github.com/jgm/pandoc/releases/download/3.1.9/pandoc-3.1.9-1-amd64.deb -o pandoc.deb
+          sudo dpkg -i pandoc.deb
       - name: Build LaTeX
         run: |
           cmake -B build ${{github.workspace}}/specs/language


### PR DESCRIPTION
There is a bug in pandoc-2.9 that causes it to fail processing the language spec. The issue is resolved on pandoc-3.1 which is not currently in the Ubuntu Jammy packages. This change just downloads the release from GitHub and installs it into the VM image.