### PR TITLE
Fix typo in 0011-inline-spirv.md

### DIFF
--- a/proposals/0011-inline-spirv.md
+++ b/proposals/0011-inline-spirv.md
@@ -245,7 +245,7 @@ file like this:
 
 ```
 [[vk::ext_extension("SPV_EXT_shader_stencil_export")]]
-[[vk::ext_builtin_input(/* FragStencilRefEXT */ 5014)]]
+[[vk::ext_builtin_output(/* FragStencilRefEXT */ 5014)]]
 void gl_FragStencilRefARB(int);
 ```
 

--- a/proposals/0011-inline-spirv.md
+++ b/proposals/0011-inline-spirv.md
@@ -220,7 +220,7 @@ like this:
 
 ```
 [[vk::ext_builtin_input(/* NumWorkgroups */ 24)]]
-uint32 gl_NumWorkGroups();
+uint3 gl_NumWorkGroups();
 ```
 
 Then the compiler will be able to add a variable to in the input storage class,


### PR DESCRIPTION
NumWorkgroups should be a uint vector with three components.