### PR TITLE
Start section on Primary Expressions

### DIFF
--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -61,3 +61,35 @@ conversions} are:
     signed integer scalar or vector element type.
   \end{itemize}
 \end{itemize}
+
+\Sec{Primary Expressions}{Expr.Primary}
+
+\begin{grammar}
+  \define{primary-expression}\br
+  literal\br
+  \keyword{this}\br
+  \texttt{(} expression \texttt{)}\br
+  id-expression\br
+\end{grammar}
+
+\Sub{Literals}{Expr.Primary.Literal}
+
+\p The type of a \textit{literal} is determined based on the grammar forms
+specified in \ref{Lex.Literal.Kinds}.
+
+\Sub{This}{Expr.Primary.This}
+
+\p The keyword \keyword{this} names a reference to the implicit object of
+non-static member functions or non-static data member initializers. The
+\keyword{this} parameter is always a \textit{prvalue} of
+non-\textit{cv-qualified}
+type\footnote{\href{https://github.com/microsoft/hlsl-specs/blob/main/proposals/0007-const-instance-methods.md}{HLSL
+Specs Proposal 0007} proposes adopting C++-like syntax and semantics for
+\textit{cv-qualified} \keyword{this} references.}.
+
+\Sub{Parenthesis}{Expr.Primary.Paren}
+
+\p An expression (\textit{E}) enclosed in parenthesis has the same type, result
+and value category as \textit{E} without the enclosing parenthesis. A
+parenthesized expression may be used in the same contexts with the same meaning
+as the same non-parenthesized expression.

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -68,7 +68,7 @@ conversions} are:
   \define{primary-expression}\br
   literal\br
   \keyword{this}\br
-  \texttt{(} expression \texttt{)}\br
+  \terminal{(} expression \terminal{)}\br
   id-expression\br
 \end{grammar}
 

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -87,12 +87,8 @@ non-static member functions. The \keyword{this} parameter is always a
   {HLSL Specs Proposal 0007} proposes adopting C++-like syntax and semantics for
   \textit{cv-qualified} \keyword{this} references.}
   
-\p A \keyword{this} expression shall not appear within the declaration of a
-static member function, except as an \textit{unevaluated operand}. When used as
-an \textit{unevaluated operand}, the type of the \keyword{this} expression is
-defined.
-
-\p The \keyword{this} expression may not appear in any other context.
+\p A \keyword{this} expression shall not appear outside the declaration of a
+non-static member function.
 
 \Sub{Parenthesis}{Expr.Primary.Paren}
 

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -91,6 +91,7 @@ non-static member functions. The \keyword{this} parameter is always a
 static member function, except as an \textit{unevaluated operand}. When used as
 an \textit{unevaluated operand}, the type of the \keyword{this} expression is
 defined.
+
 \p The \keyword{this} expression may not appear in any other context.
 
 \Sub{Parenthesis}{Expr.Primary.Paren}

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -86,6 +86,12 @@ non-static member functions. The \keyword{this} parameter is always a
   \href{https://github.com/microsoft/hlsl-specs/blob/main/proposals/0007-const-instance-methods.md}
   {HLSL Specs Proposal 0007} proposes adopting C++-like syntax and semantics for
   \textit{cv-qualified} \keyword{this} references.}
+  
+\p A \keyword{this} expression shall not appear within the declaration of a
+static member function, except as an \textit{unevaluated operand}. When used as
+an \textit{unevaluated operand}, the type of the \keyword{this} expression is
+defined.
+\p The \keyword{this} expression may not appear in any other context.
 
 \Sub{Parenthesis}{Expr.Primary.Paren}
 

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -80,12 +80,12 @@ specified in \ref{Lex.Literal.Kinds}.
 \Sub{This}{Expr.Primary.This}
 
 \p The keyword \keyword{this} names a reference to the implicit object of
-non-static member functions or non-static data member initializers. The
-\keyword{this} parameter is always a \textit{prvalue} of
-non-\textit{cv-qualified}
-type\footnote{\href{https://github.com/microsoft/hlsl-specs/blob/main/proposals/0007-const-instance-methods.md}{HLSL
-Specs Proposal 0007} proposes adopting C++-like syntax and semantics for
-\textit{cv-qualified} \keyword{this} references.}.
+non-static member functions. The \keyword{this} parameter is always a
+\textit{prvalue} of non-\textit{cv-qualified}type.
+\footnote{
+  \href{https://github.com/microsoft/hlsl-specs/blob/main/proposals/0007-const-instance-methods.md}
+  {HLSL Specs Proposal 0007} proposes adopting C++-like syntax and semantics for
+  \textit{cv-qualified} \keyword{this} references.}
 
 \Sub{Parenthesis}{Expr.Primary.Paren}
 

--- a/specs/language/macros.tex
+++ b/specs/language/macros.tex
@@ -17,7 +17,7 @@
 
 \newenvironment{grammar} {
   \newcommand{\define}[1]{{\textit{##1}\textnormal{:}}}
-  \newcommand{\terminal}[1]{{\textnormal{##1}}}
+  \newcommand{\terminal}[1]{{\texttt{##1}}}
   \newcommand{\br}{\hfill\\*}
 
   \renewcommand{\texttt}[1]{{\small\ttfamily\upshape ##1}}

--- a/specs/language/macros.tex
+++ b/specs/language/macros.tex
@@ -1,4 +1,10 @@
 %%------------------------------------------------------------------------------
+%% General formatting
+%%------------------------------------------------------------------------------
+
+\newcommand{\keyword}[1]{{\texttt{#1}}}
+
+%%------------------------------------------------------------------------------
 %% Grammar formatting
 %%------------------------------------------------------------------------------
 
@@ -12,7 +18,6 @@
 \newenvironment{grammar} {
   \newcommand{\define}[1]{{\textit{##1}\textnormal{:}}}
   \newcommand{\terminal}[1]{{\textnormal{##1}}}
-  \newcommand{\keyword}[1]{\texttt{##1}}
   \newcommand{\br}{\hfill\\*}
 
   \renewcommand{\texttt}[1]{{\small\ttfamily\upshape ##1}}


### PR DESCRIPTION
This adds wording for the first three easy categories of primary expressions:

* Literal expressions
* `this` expressions
* Parenthesized expressions

[Updated PDF](https://github.com/microsoft/hlsl-specs/files/13370668/hlsl.pdf)