### PR TITLE
Add a file to store placeholder reference points

### DIFF
--- a/specs/language/hlsl.tex
+++ b/specs/language/hlsl.tex
@@ -74,6 +74,8 @@
 \input{conversions}
 \input{expressions}
 
+\input{placeholders} % Declare placeholder references
+
 \clearpage
 
 \label{glossaries}

--- a/specs/language/introduction.tex
+++ b/specs/language/introduction.tex
@@ -102,7 +102,7 @@ computing adjacent values. In pixel shaders a \gls{quad} may represent four
 adjacent pixels and \gls{quad} operations allow passing data between adjacent
 lanes. In compute shaders quads may be one or two dimensional depending on the
 workload dimensionality described in the \texttt{numthreads} attribute on the
-entry function. (FIXME: Add reference to attribute)
+entry function (\ref{Decl.Attr.Entry}).
 
 \Sub{\gls{threadgroup}}{Intro.Model.Group}
 

--- a/specs/language/lex.tex
+++ b/specs/language/lex.tex
@@ -10,8 +10,7 @@ the \texttt{\#include} preprocessing directive conforming to the \gls{isoC}
 preprocessor specification.
 
 \p An implementation may implicitly include additional sources as required to
-expose the \acrshort{hlsl} library functionality as defined in (FIXME: Add
-reference to library chapter).
+expose the \acrshort{hlsl} library functionality as defined in (\ref{Runtime}).
 
 \Sec{Phases of Translation}{Lex.Phases}
 

--- a/specs/language/placeholders.tex
+++ b/specs/language/placeholders.tex
@@ -1,0 +1,4 @@
+\Ch{Declarations}{Decl}
+\Sec{Attributes}{Decl.Attr}
+\Sub{Entry Attributes}{Decl.Attr.Entry}
+\Ch{Runtime}{Runtime}


### PR DESCRIPTION
Declaring placeholder headings allows us to just put the references in as we're writing earlier parts of the document instead of leaving FIXME comments around.