### PR TITLE
Add stub grammar definitions and sections

### DIFF
--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -96,3 +96,40 @@ non-static member function.
 and value category as \textit{E} without the enclosing parenthesis. A
 parenthesized expression may be used in the same contexts with the same meaning
 as the same non-parenthesized expression.
+
+\Sub{Names}{Expr.Primary.ID}
+
+\begin{note}
+  The grammar and behaviors of this section are almost identical to C/C++ with
+  some subtractions (notably lambdas and destructors).
+\end{note}
+
+\begin{grammar}
+  \define{id-expression}\br
+  unqualified-id\br
+  qualified-id
+\end{grammar}
+
+\SubSub{Unqualified Identifiers}{Expr.Primary.ID.Unqual}
+
+\begin{grammar}
+  \define{unqualified-id}\br
+  identifier\br
+  operator-function-id\br
+  conversion-function-id\br
+  template-id\br
+\end{grammar}
+
+\SubSub{Qualified Identifiers}{Expr.Primary.ID.Qual}
+
+\begin{grammar}
+  \define{qualified-id}\br
+  nested-name-specifier \opt{\keyword{template}} unqualified-id\br
+  \define{nested-name-specifier}\br
+  \terminal{::}\br
+  type-name \terminal{::}\br
+  namespace-name \terminal{::}\br
+  nested-name-specifier identifier \terminal{::}\br
+  nested-name-specifier \opt{\keyword{template}} simple-template-id \terminal{::}
+\end{grammar}
+

--- a/specs/language/hlsl.tex
+++ b/specs/language/hlsl.tex
@@ -18,9 +18,11 @@
 
 \renewcommand{\familydefault}{\sfdefault}
 
+\setcounter{secnumdepth}{3} % number subsections
 \newcommand{\Ch}[2]{\chapter[#1]{#1\hfill[#2]}\label{#2}}
 \newcommand{\Sec}[2]{\section[#1]{#1\hfill[#2]}\label{#2}}
 \newcommand{\Sub}[2]{\subsection[#1]{#1\hfill[#2]}\label{#2}}
+\newcommand{\SubSub}[2]{\subsubsection[#1]{#1\hfill[#2]}\label{#2}}
 
 \input{glossary}
 
@@ -50,8 +52,15 @@
 
 \setlength\parindent{0cm}
 
-\newcounter{parcount}
-\counterwithin{parcount}{subsection}
+\newcommand{\newparcounter}[1]{
+\newcounter{#1}
+\counterwithin{#1}{chapter}
+\counterwithin{#1}{section}
+\counterwithin{#1}{subsection}
+\counterwithin{#1}{subsubsection}
+}
+
+\newparcounter{parcount}
 \newcommand\p{%
     \stepcounter{parcount}%
     \parnum \hspace{1em}%

--- a/specs/language/macros.tex
+++ b/specs/language/macros.tex
@@ -19,6 +19,7 @@
   \newcommand{\define}[1]{{\textit{##1}\textnormal{:}}}
   \newcommand{\terminal}[1]{{\texttt{##1}}}
   \newcommand{\br}{\hfill\\*}
+  \newcommand{\opt}[1]{{##1\textsubscript{\textit{opt}}}}
 
   \renewcommand{\texttt}[1]{{\small\ttfamily\upshape ##1}}
 


### PR DESCRIPTION
These are just empty placeholder sections with some grammar definitions to fill in the ID expression grammars. Properly documenting this will require going back and defining scopes and other lexical constructs.

Since all of this is more or less inherited from C/C++ I'm going to leave them as stubs for now and focus on the HLSL-specific sections.

This change also introduces numbered sub-subsections and formatting for optional grammar elements.