### PR TITLE
[Expr] Add Expr.Post.Call

### DIFF
--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -196,45 +196,45 @@ lvalue directly decays via array-to-pointer decay. \footnote{This results in
 
 \p Arguments to \textit{output} and \textit{input/output parameters} must be
 lvalues. \textit{Output parameters} are not initialized prior to the call; they
-are passed as an uninitialized cx-value (\ref{Basic.lval}). An \textit{output
+are passed as an uninitialized cxvalue (\ref{Basic.lval}). An \textit{output
 parameter} is only initialized explicitly inside the called function. It is
 undefined behavior to not explicitly initialize an \textit{output parameter}
-before returning from the function in which it is defined. The cx-value created
+before returning from the function in which it is defined. The cxvalue created
 from an argument to an \textit{input/output parameter} is initialized through
 copy-initialization from the lvalue argument expression. In both cases, the
-cx-value shall have the type of the parameter and the argument can be converted
+cxvalue shall have the type of the parameter and the argument can be converted
 to that type through implicit or explicit conversion.
 
 \p If an argument to an \textit{output} or \textit{input/output parameter} is a
-constant sized array, the array is copied to a temporary cx-value following the
+constant sized array, the array is copied to a temporary cxvalue following the
 same rules for any other data type. If an argument to an \textit{output} or
 \textit{input/output parameter} is an unsized array type, the array lvalue
 directly decays via array-to-pointer decay. An argument of a constant sized
-array of type \texttt{T[N]} can be converted to a cx-value of an unsized array
+array of type \texttt{T[N]} can be converted to a cxvalue of an unsized array
 of type \texttt{T[]} through array to pointer decay. An unsized array of type
 \texttt{T[]}, cannot be implicitly converted to a a constant sized array of type
 \texttt{T[N]}.
 
-\p On expiration of the cx-value, the value is assigned back to the argument
+\p On expiration of the cxvalue, the value is assigned back to the argument
 lvalue expression following an inverted conversion if applicable. The argument
 expression must be of a type or able to convert to a type that has defined
-copy-initialization to and from the parameter type. The lifetime of the cx-value
+copy-initialization to and from the parameter type. The lifetime of the cxvalue
 begins at argument expression evaluation, and ends after the function returns. A
-cx-value argument is passed by-address to the caller.
+cxvalue argument is passed by-address to the caller.
 
 \p If the lvalue passed to an \textit{output} or \textit{input/output parameter}
 does not alias any other parameter passed to that function, an implementation
 may avoid the creation of excess temporaries by passing the address of the
-lvalue instead of creating the cx-value.
+lvalue instead of creating the cxvalue.
 
 \p When a function is called, any parameter of object type must have completely
 defined type, and any parameter of array of object type must have completely
 defined element type.\footnote{HLSL \textit{output} and \textit{input/output
 parameters} are passed by value, so they must also have complete type.} The
 lifetime of a parameter ends on return of the function in which it is
-defined.\footnote{As stated above cx-value parameters are passed-by-address, so
-the expiring parameter is the reference to the address, not the cx-value. The
-cx-value expires in the caller.} Initialization and destruction of each
+defined.\footnote{As stated above cxvalue parameters are passed-by-address, so
+the expiring parameter is the reference to the address, not the cxvalue. The
+cxvalue expires in the caller.} Initialization and destruction of each
 parameter occurs within the context of the calling function.
 
 \p The value of a function call is the value returned by the called function.

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -172,7 +172,7 @@ is a member function name.
 
 \p When a function is called, each parameter shall be initialized with its
 corresponding argument. The order in which parameters are initialized is
-undefined. \footnote{Today in DXC targeting DXIL matches the Microsoft C++ ABI
+unspecified. \footnote{Today in DXC targeting DXIL matches the Microsoft C++ ABI
 and evaluates argument expressions right-to-left, while SPIR-V generation
 matches the Itanium ABI evaluating parameters left-to-right. There are good
 arguments for unifying these behaviors, and arguments for keeping them

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -180,7 +180,8 @@ different.}
 
 \p If the function is a non-static member function the \texttt{this} argument
 shall be initialized to a reference to the object of the call as if casted by an
-explicit cast expression.
+explicit cast expression to an lvalue reference of the type that the function is
+declared as a member of.
 
 \p Parameters are either \textit{input parameters}, \textit{output parameters},
 or \textit{input/output parameters} as denoted in the called function's
@@ -226,20 +227,20 @@ does not alias any other parameter passed to that function, an implementation
 may avoid the creation of excess temporaries by passing the address of the
 lvalue instead of creating the cx-value.
 
-\p When a function is called parameters with object type must have completely
-defined type, and parameters of array of object must have completely defined
-element type.\footnote{HLSL \textit{output} and \textit{input/output parameters}
-are passed by value, so they must also have complete type.} The lifetime of a
-parameter ends on return of the function in which it is defined.\footnote{As
-stated above cx-value parameters are passed-by-address, so the expiring
-parameter is the reference to the address, not the cx-value. The cx-value
-expires in the caller.} Initialization and destruction of each parameter occurs
-within the context of the calling function.
+\p When a function is called, any parameter of object type must have completely
+defined type, and any parameter of array of object type must have completely
+defined element type.\footnote{HLSL \textit{output} and \textit{input/output
+parameters} are passed by value, so they must also have complete type.} The
+lifetime of a parameter ends on return of the function in which it is
+defined.\footnote{As stated above cx-value parameters are passed-by-address, so
+the expiring parameter is the reference to the address, not the cx-value. The
+cx-value expires in the caller.} Initialization and destruction of each
+parameter occurs within the context of the calling function.
 
 \p The value of a function call is the value returned by the called function.
 
 \p A function call is an lvalue if the result type is an lvalue reference type;
 otherwise it is a prvalue.
 
-\p If a function call is a prvalue of object type, the type of the prvalue shall
+\p If a function call is a prvalue of object type, the type of the prvalue must
 be complete.

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -160,3 +160,86 @@ the form \texttt{E1[E2]}, \texttt{E1} must either be a variable of array of
 overloaded implementation of \texttt{operator[]} (\ref{Overload}).\footnote{HLSL
 does not support the base address of a subscript operator being the expression
 inside the braces, which is valid in C and C++.}
+
+\Sec{Function Calls}{Expr.Post.Call}
+
+\p A function call may be an \textit{ordinary function}, or a \textit{member
+function}. In a function call to an \textit{ordinary function}, the
+\textit{postfix-expression} must be an lvalue that refers to a function. In a
+function call to a \textit{member function}, the \textit{postfix-expression}
+will be an implicit or explicit class member access whose \textit{id-expression}
+is a member function name.
+
+\p When a function is called, each parameter shall be initialized with its
+corresponding argument. The order in which parameters are initialized is
+undefined. \footnote{Today in DXC targeting DXIL matches the Microsoft C++ ABI
+and evaluates argument expressions right-to-left, while SPIR-V generation
+matches the Itanium ABI evaluating parameters left-to-right. There are good
+arguments for unifying these behaviors, and arguments for keeping them
+different.}
+
+\p If the function is a non-static member function the \texttt{this} argument
+shall be initialized to a reference to the object of the call as if casted by an
+explicit cast expression.
+
+\p Parameters are either \textit{input parameters}, \textit{output parameters},
+or \textit{input/output parameters} as denoted in the called function's
+declaration (\ref{Decl.Function}).
+
+\p \textit{Input parameters} are passed by-value into a function. If an argument
+to an \textit{input parameter} is of constant-sized array type, the array is
+copied to a temporary and the temporary value is converted to an address via
+array-to-pointer decay. If an argument is an unsized array type, the array
+lvalue directly decays via array-to-pointer decay. \footnote{This results in
+\textit{input} parameters of unsized arrays being modifiable by a function.}
+
+\p Arguments to \textit{output} and \textit{input/output parameters} must be
+lvalues. \textit{Output parameters} are not initialized prior to the call; they
+are passed as an uninitialized cx-value (\ref{Basic.lval}). An \textit{output
+parameter} is only initialized explicitly inside the called function. It is
+undefined behavior to not explicitly initialize an \textit{output parameter}
+before returning from the function in which it is defined. The cx-value created
+from an argument to an \textit{input/output parameter} is initialized through
+copy-initialization from the lvalue argument expression. In both cases, the
+cx-value shall have the type of the parameter and the argument can be converted
+to that type through implicit or explicit conversion.
+
+\p If an argument to an \textit{output} or \textit{input/output parameter} is a
+constant sized array, the array is copied to a temporary cx-value following the
+same rules for any other data type. If an argument to an \textit{output} or
+\textit{input/output parameter} is an unsized array type, the array lvalue
+directly decays via array-to-pointer decay. An argument of a constant sized
+array of type \texttt{T[N]} can be converted to a cx-value of an unsized array
+of type \texttt{T[]} through array to pointer decay. An unsized array of type
+\texttt{T[]}, cannot be implicitly converted to a a constant sized array of type
+\texttt{T[N]}.
+
+\p On expiration of the cx-value, the value is assigned back to the argument
+lvalue expression following an inverted conversion if applicable. The argument
+expression must be of a type or able to convert to a type that has defined
+copy-initialization to and from the parameter type. The lifetime of the cx-value
+begins at argument expression evaluation, and ends after the function returns. A
+cx-value argument is passed by-address to the caller.
+
+\p If the lvalue passed to an \textit{output} or \textit{input/output parameter}
+does not alias any other parameter passed to that function, an implementation
+may avoid the creation of excess temporaries by passing the address of the
+lvalue instead of creating the cx-value.
+
+\p When a function is called parameters with object type must have completely
+defined type, and parameters of array of object must have completely defined
+element type.\footnote{HLSL \textit{output} and \textit{input/output parameters}
+are passed by value, so they must also have complete type.} The lifetime of a
+parameter ends on return of the function in which it is defined.\footnote{As
+stated above cx-value parameters are passed-by-address, so the expiring
+parameter is the reference to the address, not the cx-value. The cx-value
+expires in the caller.} Initialization and destruction of each parameter occurs
+within the context of the calling function.
+
+\p The value of a function call is the value returned by the called function.
+
+\p A function call is an lvalue if the result type is an lvalue reference type;
+otherwise it is a prvalue.
+
+\p If a function call is a prvalue of object type, the type of the prvalue shall
+be complete.

--- a/specs/language/placeholders.tex
+++ b/specs/language/placeholders.tex
@@ -1,4 +1,5 @@
 \Ch{Declarations}{Decl}
+\Sec{Function Definitions}{Decl.Function}
 \Sec{Attributes}{Decl.Attr}
 \Sub{Entry Attributes}{Decl.Attr.Entry}
 \Ch{Overloading}{Overload}


### PR DESCRIPTION
This section specifies how HLSL function calls work as well as how argument and paramters are represented, their lifetimes and semantics.