### PR TITLE
Fix failing GitHub action to deploy docs

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/configure-pages@v2
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt -y install texlive
           sudo apt -y install texlive-latex-extra
           curl -fsSL https://github.com/jgm/pandoc/releases/download/3.1.9/pandoc-3.1.9-1-amd64.deb -o pandoc.deb


### PR DESCRIPTION
Our doc build started failing due to a change in the azure images. The failure is the same as what is reported in this issue: https://github.com/actions/runner-images/issues/7603.

The fix described there is to call `sudo apt-get update`, which is the change here.