### PR TITLE
Add pre-merge build

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -54,6 +54,11 @@ jobs:
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
+      - if: ${{ github.event_name == 'pull_request'}}
+        uses: actions/upload-artifact@v4
+        with:
+          name: PDF
+          path: ${{github.workspace}}/specs/hlsl.pdf
 
   # Deployment job
   deploy:

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -5,6 +5,10 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  pull_request:
+    types: [opened,synchronize]
+    paths:
+      - specs/language/**
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -53,6 +57,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: ${{ github.event_name == 'push'}}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -138,8 +138,8 @@ as the same non-parenthesized expression.
 \begin{grammar}
   \define{postfix-expression}\br
   primary-expression\br
-  postfix-expression \terminal{[} expression \terminal{]}\br
-  postfix-expression \terminal{[} braced-init-list \terminal{]}\br
+  postfix-expression [ expression ]\br
+  postfix-expression [ braced-init-list ]\br
   postfix-expression \terminal{(} \opt{expression-list} \terminal{)}\br
   simple-type-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
   typename-specifier \terminal{(} \opt{expression} \terminal{)}\br


### PR DESCRIPTION
This enables the documentation build to run when the LaTeX is modified in a PR.

As initially posted this change includes part of the change from PR #145 so that there is a modified file in the spec to force a build to trigger.

Fixes #143