### PR TITLE
Add extended command info spec 

### DIFF
--- a/proposals/0015-extended-command-info.md
+++ b/proposals/0015-extended-command-info.md
@@ -108,7 +108,7 @@ $result2 = call i32 @dx.op.StartInstanceLocation(i32 257)
 
 Use of HLSL entry parameters with the new semantic annotations
  `SV_StartInstanceLocation` or `SV_StartVertexLocation` can be supported in
- SPIR-V using OpVariables with the result <id> of the OpVariable set to
+ SPIR-V using OpVariables with the result id of the OpVariable set to
  `BaseInstance`(4425) or `BaseVertex`(4424) respectively.
 
 ### Diagnostic Changes

--- a/proposals/0015-extended-command-info.md
+++ b/proposals/0015-extended-command-info.md
@@ -1,0 +1,148 @@
+# Extended Command Information
+
+v0.4 2023-09-27
+
+Three new system-value semantics are required to be supported in HLSL shader model 6.8:
+
+* SV_StartVertexLocation -
+ Reports StartVertexLocation from DrawInstanced()
+ or BaseVertexLocation from DrawIndexedInstanced() to a vertex shader.
+* SV_StartInstanceLocation -
+ Reports StartInstanceLocation From Draw*Instanced to a vertex shader.
+* SV_IndirectCommandIndex -
+ Reports the auto-incrementing index of the current indirect command operation
+ to a shader.
+
+Since SV_VertexID doesn't include the StartVertexLocation
+ and SV_InstanceID doesn't include the StartInstanceLocation values provided to the API
+ through the corresponding draw or execute calls,
+ this information has been unavailable to HLSL unless independently passed in.
+Availability of these values allows reconstruction of the vertex and instance representation
+ used within the API.
+It also provides compatibility support for APIs that include these values
+ in their VertexID and PrimitiveID equivalents.
+
+## Contents
+
+* [SV_StartVertexLocation](#sv_startvertexlocation)
+* [SV_StartInstanceLocation](#sv_startinstancelocation)
+* [SV_IndirectCommandIndex](#sv_indirectcommandindex)
+* [DXIL](#dxil)
+* [Device Capability](#device-capability)
+* [Issues](#issues)
+* [Change Log](#change-log)
+
+## SV_StartVertexLocation
+
+| Semantic Input | Type |
+|---------------------------|--------|
+| SV_StartVertexLocation | int |
+
+Value added to each index before reading a vertex from vertex buffer(s) if present.
+Regardless of presence or use of vertex buffers,
+ the value will behave the same and the shader can use this
+ or any other system value for any purpose.
+It corresponds to StartVertexLocation from the underlying DrawInstanced() call,
+ to BaseVertexLocation from the underyling DrawIndexedInstanced() call,
+ or to equivalent parameters to the the equivalent indirect calls from ExecuteIndirect()
+ on the command list.
+
+The value is signed to allow for negative values
+ just like the BaseVertexLocation parameter is.
+A negative BaseVertexLocation allows the first vertex to be referenced
+ by a positive vertex index value that is shifted to a lower value,
+ but should not index below zero.
+The StartVertexLocation parameter is unsigned and
+ it will continue to be used as unsigned when reading vertex data
+ but will be reinterpret casted to a signed int for HLSL.
+
+The system only populates this as input to the vertex shader.
+For any subsequent stage that cares about this value, the shader must pass it manually
+ using a user semantic.
+SV_StartVertexLocation is an invalid semantic for any shader outputs.
+
+## SV_StartInstanceLocation
+
+| Semantic Input | Type |
+|---------------------------|--------|
+| SV_StartInstanceLocation  | uint       |
+
+Value added to each index before reading instance data from instance buffer(s) if present.
+Regardless of presence or use of instance buffers,
+ the value will behave the same and the shader can use this
+ or any other system value for any purpose.
+It corresponds to StartInstanceLocation from the underlying Draw*Instanced() call
+ or equivalent indirect call from ExecuteIndirect() on the command list.
+
+For shader invocations outside Draw*Instanced()
+ or corresponding indirect call from ExecuteIndirect(),
+ SV_StartInstanceLocation is always 0.
+
+The system only populates this as input to the vertex shader.
+For any subsequent stage that cares about this value, the shader must pass it manually
+ using a user semantic.
+SV_StartVertexLocation is an invalid semantic for any shader outputs.
+<!-- See issue 1 -->
+
+## SV_IndirectCommandIndex
+
+| Semantic Input | Type |
+|---------------------------|--------|
+| SV_IndirectCommandIndex | uint |
+
+Index of the current command in an ExecuteIndirect() call.
+Within an ExecuteIndirect() call, SV_IndirectCommandIndex starts at 0 for its first command
+ and increments by one for each subsequent command.
+For shader invocations outside ExecuteIndirect(), SV_IndirectCommandIndex is always 0.
+
+The system will populate this as a system value input to vertex, mesh and amplification shader stages.
+SV_IndirectCommandIndex is an invalid tag for any shader outputs.
+<!-- See issue 3 -->
+
+## DXIL
+
+Three new DXIL operations that return the three semantic values are introduced in DXIL 1.8.
+The associated opcodes are the only parameters.
+
+```C++
+// SV_StartVertexLocation
+$result1 = call i32 @dx.op.StartVertexLocation(i32 256)
+
+// SV_StartInstanceLocation
+$result2 = call i32 @dx.op.StartInstanceLocation(i32 257)
+
+// SV_IndirectCommandIndex
+$result3 = call i32 @dx.op.IndirectCommandIndex(i32 258)
+```
+
+## Device Capability
+
+Devices that support `D3D_SHADER_MODEL_6_8` are required to support these system values.
+
+## Issues
+
+1. For which shader stages should these values be available?
+   * StartVertexLocation and StartPrintiveLocation are available to the vertex shader
+     stage through system value inputs.
+     They cannot be used on output variables.
+     SV_IndirectCommandIndex is available to all shader stages.
+
+2. How should SV_StartVertexLocation and SV_StartInstanceLocation be accessed?
+   * Though these could be built-in functions,
+     semantic values are consistent with how the corresponding existing information
+     is accessed.
+
+3. How should SV_IndirectCommandIndex be accessed?
+   * UNRESOLVED: Some implmenetations of ExecuteIndirect involving replays
+     will have a problem with the semantic value.
+     Perhaps instead might use an incrementing root constant
+     that increments by one for each invocation.
+
+## Change Log
+
+Version|Date|Description
+-|-|-
+0.4|27 Sep 2023|Limit StartInstanceLocation to vertex shaders
+0.3|27 Sep 2023|clarified signed int. added command idx issue. fixed copy/paste issues
+0.2|25 Sep 2023|Renamed BaseVertexLocation. Allowed multiple stages. Clarified value definitions.
+0.1|25 Sep 2023|Initial version

--- a/proposals/0015-extended-command-info.md
+++ b/proposals/0015-extended-command-info.md
@@ -61,9 +61,6 @@ Regardless of presence or use of instance buffers,
 It corresponds to `StartInstanceLocation` from the underlying `DrawInstanced()`
  or `DrawIndexedInstanced()` call
  or equivalent indirect call from `ExecuteIndirect()` on the command list.
-For shader invocations outside `DrawInstanced()`, `DrawIndexedInstanced()`
- or corresponding indirect call from `ExecuteIndirect()`,
- `SV_StartInstanceLocation` is always zero.
 
 `SV_StartVertexLocation` represents the value added to each index before reading
  a vertex from vertex buffer(s) if present.

--- a/proposals/0015-extended-command-info.md
+++ b/proposals/0015-extended-command-info.md
@@ -8,14 +8,15 @@
 
 ## Introduction
 
-Two new system-value semantics are required to be supported in HLSL shader
+Two new system-value semantics are to be supported in HLSL shader
  model 6.8:
 
-* SV_StartVertexLocation -
- Reports StartVertexLocation from DrawInstanced()
- or BaseVertexLocation from DrawIndexedInstanced() to a vertex shader.
+* `SV_StartVertexLocation` -
+ Reports `StartVertexLocation` from `DrawInstanced()`
+ or `BaseVertexLocation` from `DrawIndexedInstanced()` to a vertex shader.
 * SV_StartInstanceLocation -
- Reports StartInstanceLocation From Draw*Instanced to a vertex shader.
+ Reports `StartInstanceLocation` from `DrawInstanced()` or
+ `DrawIndexedInstanced()` to a vertex shader.
 
 ## Motivation
 
@@ -29,71 +30,71 @@ In particular, if the vertex or instance information is offset by a certain
  amount in the API, the shader can access that information and potentially
  make use of data before that offset for special usage.
 It also provides compatibility support for APIs that include these values
- in their VertexID and PrimitiveID equivalents.
+ in their VertexID and InstanceID equivalents.
 
 ## Proposed solution
+
+The values provided to `DrawInstanced()` or `DrawIndexInstanced()` that
+ represent the start or base vertex and instance location should be made
+ available through semantic values applied to parameters to the entry function
+ of a vertex shader.
+These values will be lowered to DXIL intrinsics that represent a
+ platform-specific mechanism to retrieve the corresponding values provided by
+ the API draw call that invoked the vertex shader.
 
 ## Detailed Design
 
 ### HLSL additions
 
-##### SV_StartVertexLocation
-
 New semantic inputs are added to HLSL vertex shaders.
 
-| Semantic Input | Type |
-|---------------------------|--------|
-| SV_StartVertexLocation | int |
+|     Semantic Input        | Type | Stages |
+|---------------------------|------|--------|
+| SV_StartInstanceLocation  | uint | Vert   |
+| SV_StartVertexLocation    | int  | Vert   |
 
-Value added to each index before reading a vertex from vertex buffer(s) if present.
-Regardless of presence or use of vertex buffers,
- the value will behave the same and the shader can use this
- or any other system value for any purpose.
-It corresponds to StartVertexLocation from the underlying DrawInstanced() call,
- to BaseVertexLocation from the underyling DrawIndexedInstanced() call,
- or to equivalent parameters to the the equivalent indirect calls from ExecuteIndirect()
- on the command list.
-
-The value is signed to allow for negative values
- just like the BaseVertexLocation parameter is.
-A negative BaseVertexLocation allows the first vertex to be referenced
- by a positive vertex index value that is shifted to a lower value,
- but should not index below zero.
-The StartVertexLocation parameter is unsigned and
- it will continue to be used as unsigned when reading vertex data
- but will be reinterpret casted to a signed int for HLSL.
-
-The system only populates this as input to the vertex shader.
-For any subsequent stage that cares about this value, the shader must pass it manually
- using a user semantic.
-SV_StartVertexLocation is an invalid semantic for any shader outputs.
-
-##### SV_StartInstanceLocation
-
-| Semantic Input | Type |
-|---------------------------|--------|
-| SV_StartInstanceLocation  | uint       |
-
-Value added to each index before reading instance data from instance buffer(s) if present.
+`SV_StartInstanceLocation` represents the value added to each index before
+ reading instance data from instance buffer(s) if present.
 Regardless of presence or use of instance buffers,
  the value will behave the same and the shader can use this
  or any other system value for any purpose.
-It corresponds to StartInstanceLocation from the underlying Draw*Instanced() call
- or equivalent indirect call from ExecuteIndirect() on the command list.
+It corresponds to `StartInstanceLocation` from the underlying `DrawInstanced()`
+ or `DrawIndexedInstanced()` call
+ or equivalent indirect call from `ExecuteIndirect()` on the command list.
+For shader invocations outside `DrawInstanced()`, `DrawIndexedInstanced()`
+ or corresponding indirect call from `ExecuteIndirect()`,
+ `SV_StartInstanceLocation` is always zero.
 
-For shader invocations outside Draw*Instanced()
- or corresponding indirect call from ExecuteIndirect(),
- SV_StartInstanceLocation is always 0.
+`SV_StartVertexLocation` represents the value added to each index before reading
+ a vertex from vertex buffer(s) if present.
+Regardless of presence or use of vertex buffers,
+ the value will behave the same and the shader can use this
+ or any other system value for any purpose.
+It corresponds to `StartVertexLocation` from the underlying `DrawInstanced()` call,
+ to `BaseVertexLocation` from the underlying `DrawIndexedInstanced()` call,
+ or to equivalent parameters to the the equivalent indirect calls from ExecuteIndirect()
+ on the command list.
+`SV_StartVertexLocation` is signed to allow for negative values
+ just like the `BaseVertexLocation` parameter is.
+A negative value allows the first vertex to be referenced
+ by a positive vertex index value that is shifted to a lower value,
+ but should not index below zero.
+The `StartVertexLocation` parameter to `DrawInstanced()` is unsigned and
+ it will continue to be used as unsigned when reading vertex data
+ but will be reinterpret-casted to a signed int for HLSL.
 
-The system only populates this as input to the vertex shader.
-For any subsequent stage that cares about this value, the shader must pass it manually
+The system only populates these values as inputs to the vertex shader.
+For any subsequent stage that cares about them, the shader must pass them manually
  using a user semantic.
-SV_StartVertexLocation is an invalid semantic for any shader outputs.
+These semantics are invalid for any shader outputs.
 
 ### DXIL Additions
 
-Two new DXIL operations that return the two semantic values are introduced in DXIL 1.8.
-The associated opcodes are the only parameters.
+Two new DXIL operations that return the two semantic values are introduced in
+ DXIL 1.8.
+As they return values that are determined by the draw calls,
+ they require no input from the shader and have only the associated opcodes as
+ parameters.
 
 ```C++
 // SV_StartVertexLocation
@@ -105,15 +106,40 @@ $result2 = call i32 @dx.op.StartInstanceLocation(i32 257)
 
 ### SPIR-V Additions
 
+Use of HLSL entry parameters with the new semantic annotations
+ `SV_StartInstanceLocation` or `SV_StartVertexLocation` can be supported in
+ SPIR-V using OpVariables with the result <id> of the OpVariable set to
+ `BaseInstance`(4425) or `BaseVertex`(4424) respectively.
+
 ### Diagnostic Changes
 
 #### New Errors
 
+These are where new errors are produced:
+
+* A parameter with `SV_StartInstanceLocation` is not `uint` type.
+  (currently blocked by  bug [#5768](https://github.com/microsoft/DirectXShaderCompiler/issues/5768))
+* A parameter with `SV_StartVertexLocation` is not `int` type.
+  (currently blocked by  bug [#5768](https://github.com/microsoft/DirectXShaderCompiler/issues/5768))
+* `SV_StartVertexLocation` or `SV_StartInstanceLocation` are used
+  in any non-vertex shader stages
+* `SV_StartVertexLocation` or `SV_StartInstanceLocation` are used on any vertex
+  shader outputs.
+* `SV_StartVertexLocation` or `SV_StartInstanceLocation` are used
+  in a vertex shader targeting a shader model earlier than 6.8.
+
 #### Validation Changes
+
+Validation should confirm:
+
+* That neither `dx.op.StartVertexLocation` nor `dx.op.StartInstanceLocation`
+  are used in any DXIL compiled for any non-vertex shader stage.
 
 ### Runtime Additions
 
 #### Runtime information
+
+No additions are needed here.
 
 #### Device Capability
 
@@ -123,13 +149,65 @@ Devices that support `D3D_SHADER_MODEL_6_8` are required to support these system
 
 ### Correct Behavior Testing
 
-#### Diagnostics Testing
+Verify the following compiler output:
+
+* A vertex shader with an int entry point parameter annotated with
+  `SV_StartInstanceLocation` that is passed directly into the output produces
+  DXIL IR with a call op to `dx.op.StartInstanceLocation` that returns that
+  result to the output.
+* A vertex shader with an input struct with an element annotated with
+  `SV_StartInstanceLocation` that is passed directly into the output produces
+  DXIL IR with a call op to `dx.op.StartInstanceLocation` that returns that
+  result to the output.
+* A vertex shader with an int entry point parameter annotated with
+  `SV_StartVertexLocation` that is passed directly into the output produces
+  DXIL IR with a call op to `dx.op.StartVertexLocation` that returns that
+  result to the output.
+* A vertex shader with an input struct with an element annotated with
+  `SV_StartVertexLocation` that is passed directly into the output produces
+  DXIL IR with a call op to `dx.op.StartVertexLocation` that returns that
+  result to the output.
+* Each of the above tests produces the expected output within a library shader
+  with a "vertex" shader attribute.
+
+### Diagnostics Testing
+
+Ensure that each of the following scenarios produces appropriate errors:
+
+* Use invalid types for entry parameters with the new semantics
+  (currently blocked by  bug [#5768](https://github.com/microsoft/DirectXShaderCompiler/issues/5768))
+  * A `float` parameter with `SV_StartInstanceLocation`
+  * An `int` parameter with `SV_StartInstanceLocation`
+  * A `float` parameter with `SV_StartVertexLocation`
+  * A `uint` parameter with `SV_StartInstanceLocation`
+* Use new semantics in invalid shader targets
+  * `SV_StartVertexLocation` is used in each 6.8 non-vertex shader stage target
+  * `SV_StartInstanceLocation` is used in each 6.8 non-vertex shader stage target
+  * `SV_StartVertexLocation` is used in a 6.7 vertex shader stage target
+  * `SV_StartInstanceLocation` is used in a 6.7 vertex shader stage target
+
 ### Validation Testing
+
+Assemble shaders targeting each non-vertex shader stage with calls to
+ `dx.op.StartInstanceLocation` and `dx.op.StartVertexLocation` and ensure that
+ the validator produces an appropriate error.
+
 ### Execution Testing
+
+Create a vertex shader with a uint entry point parameter annotated with
+ `SV_StartInstanceLocation` and an int entry point parameter annotated with
+ `SV_StartVertexLocation` that stores those values into a raw buffer.
+Invoke this shader using `DrawInstanced()`, `DrawIndexedInstanced()`, and
+ equivalent indirect call from `ExecuteIndirect()` with positive integer values
+ for the parameters that correspond to start vertex and start instance values.
+Read back the content of the raw buffer to ensure that the values match the
+ parameters used in the API calls.
+Perform an additional test where the start vertex parameters are negative values
+ and ensure that the read back values match the parameters.
 
 ## Alternatives considered
 
-There may have been utility to making StartVertexLocation and StartPrimitiveLocation
+There may have been utility to making StartVertexLocation and StartInstanceLocation
  available in entry shader stages beyond just the vertex shader.
 That would have exceeded the requirement that motivated this feature without
  certainty that it would be useful for anyone,
@@ -144,8 +222,8 @@ It was a technical possibility that would have made them more readily available
 For the sake of consistency and the principal of least surprise,
  they are represented as semantic values as well.
 
-
 ## Acknowledgements
 
+* Jesse Natalie
 * Amar Patel
 * Tex Riddell

--- a/proposals/0015-extended-command-info.md
+++ b/proposals/0015-extended-command-info.md
@@ -1,6 +1,6 @@
 # Extended Command Information
 
-* Proposal: [NNNN](NNNN-extended-command-info.md)
+* Proposal: [0015](0015-extended-command-info.md)
 * Author(s): [Greg Roth](https://github.com/pow2clk)
 * Sponsor: [Greg Roth](https://github.com/pow2clk)
 * Status: **Under Consideration**


### PR DESCRIPTION
Specification for SV_StartVertexLocation and SV_StartInstanceLocation semantics. Documents DXIL and SPIR-V interfaces, new diagnostics, and testing suggestions.