### PR TITLE
Add subsection on derivative operations

### DIFF
--- a/proposals/0019-mesh-nodes.md
+++ b/proposals/0019-mesh-nodes.md
@@ -275,6 +275,13 @@ Some restrictions on the function use and interactions with output arrays follow
 See [SetMeshOutputCounts](https://github.com/microsoft/DirectX-Specs/blob/master/d3d/MeshShader.md#setmeshoutputcounts)
 in the mesh shader spec for specific details, restrictions, and examples.
 
+### Derivative Operations
+Because mesh shaders and node shaders with the broadcasting launch mode both support
+derivative operations, the new `mesh` node will also support derivative
+operations. The support of derivative operations is part of the 
+`DerivativesInMeshAndAmplificationShadersSupported` optional feature.
+
+
 ### Interchange Format Additions
 
 To the `DXIL::NodeLaunchType` enum, add `Mesh` (4).

--- a/proposals/0019-mesh-nodes.md
+++ b/proposals/0019-mesh-nodes.md
@@ -276,11 +276,11 @@ See [SetMeshOutputCounts](https://github.com/microsoft/DirectX-Specs/blob/master
 in the mesh shader spec for specific details, restrictions, and examples.
 
 ### Derivative Operations
+
 Because mesh shaders and node shaders with the broadcasting launch mode both support
 derivative operations, the new `mesh` node will also support derivative
 operations. The support of derivative operations is part of the 
 `DerivativesInMeshAndAmplificationShadersSupported` optional feature.
-
 
 ### Interchange Format Additions
 


### PR DESCRIPTION
The mesh nodes spec isn't clear about whether or not derivative operations will be supported. This PR adds a subsection addressed to derivative operation support, and explains why the support is present.