### PR TITLE
Add details about existing nano-COM compiler library and include description of features and code snippet usage

### DIFF
--- a/proposals/0016-c-interface-compiler-library.md
+++ b/proposals/0016-c-interface-compiler-library.md
@@ -63,12 +63,13 @@ supports the following features.
 * [PDB Symbol Access](#shader-pdbs)
 
 These features will also need to be supported by the new c-style library.
-Code snippets on how to compile a shader using the COM library are located
+Code snippets on how to use the COM library are located
 in [DXC api code snippets](#dxc-code-snippets).
 
+### DXC Library Api descriptions and code snippets
 
 The following interfaces are used to work with data being passed to/from the
-library.
+DXC library.
 
 #### Buffers
 

--- a/proposals/0016-c-interface-compiler-library.md
+++ b/proposals/0016-c-interface-compiler-library.md
@@ -49,12 +49,14 @@ will also be addressed in this proposal. The design will help migration of
 older DXC-based solutions to adopt clang as the preferred HLSL compiler.
 
 ## Detailed design
+
+### What is provided today in the DXC api?
 The current DirectX shader compiler library is a nano-COM implementation that
 supports the following features.
 
 * [Include Handlers](#include-handlers)
-* [Compiler](#compile-shader)
-* [Linker](#link-shader)
+* [Compiler](#shader-compiler)
+* [Linker](#shader-linker)
 * [Validation](#shader-validation)
 * [Reflection Data Access](#shader-reflection)
 * [DXIL Container Access](#dxil-container-access)
@@ -250,7 +252,7 @@ struct IDxcIncludeHandler : public IUnknown {
 };
 ```
 
-#### Compile Shader
+#### Shader Compiler
 IDxcCompiler3 is the most current entrypoint for compiling a shader or 
 disassembling DXIL containers/bitcode.
 
@@ -278,7 +280,7 @@ struct IDxcCompiler3 : public IUnknown {
                                          // text, and errors
 };
 ```
-#### Link Shader
+#### Shader Linker
 Links a shader and produces a shader blob that can be consumed by the D3D
 runtime.
 

--- a/proposals/0016-c-interface-compiler-library.md
+++ b/proposals/0016-c-interface-compiler-library.md
@@ -60,6 +60,11 @@ supports the following features.
 * [DXIL Container Access](#dxil-container-access)
 * [PDB Symbol Access](#shader-pdbs)
 
+These features will also need to be supported by the new c-style library.
+Code snippets on how to compile a shader using the COM library are located
+in [DXC api code snippets](#dxc-code-snippets).
+
+
 The following interfaces are used to work with data being passed to/from the
 library.
 
@@ -346,9 +351,10 @@ struct IDxcContainerReflection : public IUnknown {
 ```
 
 #### Shader PDBs
-The PDB utility library works on an existing PDB or DXIL and provides access
-to symbol information for a shader. This is useful for tooling that want
-a deeper view into the symbols for a better shader debugging experience. 
+A PDB utility library is provided and can operate on existing PDB data or
+DXIL and provides access to symbol information for a shader. This is useful for
+inspecting symbols to get a deeper view and provide better shader debugging
+experience. 
 ```c++
 struct IDxcPdbUtils : public IUnknown {
   HRESULT Load(IDxcBlob *pPdbOrDxil);
@@ -437,6 +443,24 @@ struct IDxcOptimizer : public IUnknown {
     IDxcBlobEncoding **ppOutputText);
 };
 ```
+
+## DXC Code Snippets
+
+### Compiling a shader
+```c++
+// How to compile a shader
+```
+
+### Optimizing a shader
+```c++
+// How to inspect reflection data
+```
+
+### Inspecting reflection data and working with DXIL containers
+```c++
+// How to inspect reflection data
+```
+
 
 ## Alternatives considered for supporting legacy toolchains
 

--- a/proposals/0016-c-interface-compiler-library.md
+++ b/proposals/0016-c-interface-compiler-library.md
@@ -486,8 +486,7 @@ com_ptr<IDxcBlobUtf8> errors;
 check_hresult(compileResult->GetOutput(DXC_OUT_ERRORS, IID_PPV_ARGS(errors.put()),nullptr));
 if (errors && errors->GetStringLength() > 0) {
     // Compile failed, details are in errors->GetStringPointer()
-}
-else {
+} else {
     // Compile succeeded
 }
 ```
@@ -499,18 +498,14 @@ else {
 
 ### Inspecting reflection data and working with DXIL containers
 ```c++
-// How to inspect reflection data
-// ID3D12ShaderReflection
-
 com_ptr<IDxcResult> compileResult; // Obtained by calling Compile()
 
-// Get reflection data if present
+// Get reflection data with ID3D12ShaderReflection
 if (compileResult->HasOutput(DXC_OUT_REFLECTION)) {
     com_ptr<IDxcBlob> reflectionData;
     check_hresult(compileResult->GetOutput(
       DXC_OUT_REFLECTION, IID_PPV_ARGS(reflectionData.put()), nullptr));
-    if (reflectionData)
-    {
+    if (reflectionData) {
         DxcBuffer reflectionBuffer;
         reflectionBuffer.Ptr = reflectionData->GetBufferPointer();
         reflectionBuffer.Size = reflectionData->GetBufferSize();
@@ -522,11 +517,25 @@ if (compileResult->HasOutput(DXC_OUT_REFLECTION)) {
         // Get shader description from reflection information
         D3D12_SHADER_DESC desc{};
         check_hresult(shaderReflection->GetDesc(&desc));
-    }
-    else
-    {
+    } else {
         // No reflection data found
     }
+}
+
+// Get DXIL container reflection data
+if (compileResult->HasOutput(DXC_OUT_OBJECT)) {
+    com_ptr<IDxcBlob> objectData;
+    check_hresult(compileResult->GetOutput(
+      DXC_OUT_OBJECT, IID_PPV_ARGS(objectData.put()), nullptr));
+
+    com_ptr<IDxcContainerReflection> containerReflection;
+    check_hresult(DxcCreateInstance(
+      CLSID_DxcContainerReflection, IID_PPV_ARGS(containerReflection.put())));
+    check_hresult(containerReflection->Load(objectData.get()));
+
+    // DXIL Container reflection data is ready to be accessed
+} else {
+    // No compiler object data found
 }
 
 ```

--- a/proposals/0016-c-interface-compiler-library.md
+++ b/proposals/0016-c-interface-compiler-library.md
@@ -898,10 +898,7 @@ formal header/libraries that can be consumed by legacy toolchains.
 ## Resources
 
 * [DXC Api](https://learn.microsoft.com/en-us/windows/win32/api/dxcapi/)
-* [IDxcCompiler](https://learn.microsoft.com/en-us/windows/win32/api/dxcapi/ns-dxcapi-idxccompiler)
-* [IDxCompiler2](https://learn.microsoft.com/en-us/windows/win32/api/dxcapi/ns-dxcapi-idxccompiler2)
-* [IDxCompiler3](https://learn.microsoft.com/en-us/windows/win32/api/dxcapi/ns-dxcapi-idxccompiler3)
-* [IDxcCompilerArgs](https://learn.microsoft.com/en-us/windows/win32/api/dxcapi/ns-dxcapi-idxccompilerargs)
+* [ID3D12ShaderReflection](https://learn.microsoft.com/en-us/windows/win32/api/d3d12shader/nn-d3d12shader-id3d12shaderreflection)
 
 ## Acknowledgments
 

--- a/proposals/0016-c-interface-compiler-library.md
+++ b/proposals/0016-c-interface-compiler-library.md
@@ -61,6 +61,7 @@ supports the following features.
 * [Reflection Data Access](#shader-reflection)
 * [DXIL Container Access](#dxil-container-access)
 * [PDB Symbol Access](#shader-pdbs)
+* [Intellisense Apis](#intellisense)
 
 These features will also need to be supported by the new c-style library.
 Code snippets on how to use the COM library are located
@@ -160,10 +161,10 @@ struct IDxcResult : public IDxcOperationResult {
 };
 ```
 
-#### Helper library
-The shader compiler library also provides a helper library IDxcUtils that is
-used to create/consume the different data in the forms referred to above.
-It is obtained by calling DxcCreateInstance().
+#### IDxcUtils
+The shader compiler library also provides a set of utility functions via
+IDxcUtils. This can be used to create/consume the different data in the forms
+referred to above. It is obtained by calling DxcCreateInstance().
 
 ```c++
 com_ptr<IDxcUtils> utils;
@@ -381,8 +382,6 @@ about the many different parts of the shader.
 * [Buffers](#shader-buffers-description)
 * [Variables and type information](#shader-types=and-variables)
 * [Functions and parameters](#shader-functions-and-parameters)
-
-PIX uses this interface to obtain nice buffer formatting behavior for the UI.
 
 ```c++
 struct ID3D12ShaderReflection : public IUnknown {
@@ -730,6 +729,36 @@ struct IDxcPdbUtils : public IUnknown {
   HRESULT OverrideArgs(DxcArgPair *pArgPairs, UINT32 uNumArgPairs);
   HRESULT OverrideRootSignature(const WCHAR *pRootSignature);
 };
+```
+
+#### Intellisense
+There is a whole additional set of interfaces shipped as part of the dxc
+compiler download included in dxcisense.h.  These interfaces are used to
+implement shader source GUI experiences.  
+
+This document will not go into much detail on these interfaces but they do
+need to be called out as supported by the DXC library.  PIX is an example of a
+tool that currently uses these interfaces.  Support for things like this in
+clang can be done via a language server protocol.  Language service protocols
+standardize the communication between tooling and code editors.
+[Language Server Protocol](https://learn.microsoft.com/en-us/visualstudio/extensibility/language-server-protocol?view=vs-2022)
+
+```c++
+struct IDxcCursor;
+struct IDxcDiagnostic;
+struct IDxcFile;
+struct IDxcInclusion;
+struct IDxcIntelliSense;
+struct IDxcIndex;
+struct IDxcSourceLocation;
+struct IDxcSourceRange;
+struct IDxcToken;
+struct IDxcTranslationUnit;
+struct IDxcType;
+struct IDxcUnsavedFile;
+struct IDxcCodeCompleteResults;
+struct IDxcCompletionResult;
+struct IDxcCompletionString;
 ```
 
 #### Shader Validation

--- a/proposals/0016-c-interface-compiler-library.md
+++ b/proposals/0016-c-interface-compiler-library.md
@@ -455,7 +455,7 @@ struct IDxcOptimizer : public IUnknown {
 
 ### Optimizing a shader
 ```c++
-// How to inspect reflection data
+// How to optimize a shader
 ```
 
 ### Inspecting reflection data and working with DXIL containers


### PR DESCRIPTION
This commit includes details about the dxcapi nano-COM library.  

The point of this change is to ensure that there is understanding of what is supported and supplied in today's compiler library before designing any c-style exports.

The approach taken:
* What features are in the dxcapi COM library?
* What form is the data being passed around?  How is it created/manipulated etc?
* How do I compile a shader?
* How do I access reflection data?
* What are the other parts

There are still some missing snippets that will need to be added (maybe).
* How to use the linker... and what scenarios is it used for?
* How to optimize a shader?
* How to use the include handler?
* Perhaps others..
