### PR TITLE
[INF-001] Add details on availability diagnostic text

### DIFF
--- a/proposals/infra/INF-0001-availability-diagnostics.md
+++ b/proposals/infra/INF-0001-availability-diagnostics.md
@@ -270,7 +270,7 @@ may produce warnings or errors with Clang.
 
 ### Diagnostic text
 
-The diagnostic message should reflect whether the intrisics is not available
+The diagnostic message should reflect whether the intrisic is not available
 just for the particular target shader stage or the whole shader model version.
 In other words, it should be relevant to the entry point type. 
 


### PR DESCRIPTION
Add details about what the availability diagnostics text should look like based on the target shader stage and model.

Fixes #188