### PR TITLE
Update conversion ranks for minimum precision types

### DIFF
--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -56,24 +56,23 @@ template are \textit{vector types}. Vector lengths must be between 1 and 4 (i.e.
 \texttt{int32\_t}, and \texttt{int64\_t}. Each of the signed integer types is
 explicitly named for the size in bits of the type's object representation. There
 is also the type alias \texttt{int} which is an alias of \texttt{int32\_t}.
-There are three \textit{minimum precision signed integer types}:
-\texttt{min10int}, \texttt{min12int}, and \texttt{min16int}. Each of the minimum
-precision signed integer types are named for the required minimum value
-representation size in bits. The object representation of all minimum precision
-types is \texttt{int}. The standard signed integer types and minimum precision
-signed integer types are collectively called \textit{signed integer types}.
+There are two \textit{minimum precision signed integer types}:
+\texttt{min12int}, and \texttt{min16int}. Each of the minimum precision signed
+integer types are named for the required minimum value representation size in
+bits. The object representation of all minimum precision types is \texttt{int}.
+The standard signed integer types and minimum precision signed integer types are
+collectively called \textit{signed integer types}.
 
 \p There are three \textit{standard unsigned integer types}: \texttt{uint16\_t},
 \texttt{uint32\_t}, and \texttt{uint64\_t}. Each of the unsigned integer types
 is explicitly named for the size in bits of the type's object representation.
 There is also the type alias \texttt{uint} which is an alias of
-\texttt{uint32\_t}. There are three \textit{minimum precision unsigned integer
-types}: \texttt{min10uint}, \texttt{min12uint}, and \texttt{min16uint}. Each of
-the minimum precision unsigned integer types are named for the required minimum
-value representation size in bits. The object representation of all minimum
-precision types is \texttt{uint}. The standard unsigned integer types and
-minimum precision unsigned integer types are collectively called
-\textit{unsigned integer types}.
+\texttt{uint32\_t}. There is one \textit{minimum precision unsigned integer
+type}: \texttt{min16uint}. The minimum precision unsigned integer type is named
+for the required minimum value representation size in bits. The object
+representation of \texttt{min16uint} is \texttt{uint}. The standard unsigned
+integer types and minimum precision unsigned integer type are collectively
+called \textit{unsigned integer types}.
 
 \p The minimum precision signed integer types and minimum precision unsigned
 integer types are collectively called \textit{minimum precision integer types}.
@@ -95,14 +94,14 @@ as controlled by implementation defined compiler settings. If \texttt{half} is
 otherwise it will have an object representation matching the \textbf{binary16}
 format defined in \gls{IEEE754}\footnote{IEEE-754 only defines a binary encoding
 for 16-bit floating point values, it does not fully specify the behavior of such
-types.}. There are three \textit{minimum precision floating point types}:
-\texttt{min10float}, \texttt{min12float}, and \texttt{min16float}. Each of the
-minimum precision floating point types are named for the required minimum value
-representation size in bits. The object representation of all minimum precision
-types is \texttt{float}\footnote{This means when stored to memory minimum
-precision types are stored as \textbf{binary32} as defined in \gls{IEEE754}.}.
-The standard floating point types and minimum precision floating point types are
-collectively called \textit{floating point types}.
+types.}. There are two \textit{minimum precision floating point types}:
+\texttt{min10float}, and \texttt{min16float}. Each of the minimum precision
+floating point types are named for the required minimum value representation
+size in bits. The object representation of all minimum precision types is
+\texttt{float}\footnote{This means when stored to memory minimum precision types
+are stored as \textbf{binary32} as defined in \gls{IEEE754}.}. The standard
+floating point types and minimum precision floating point types are collectively
+called \textit{floating point types}.
 
 \p Integer and floating point types are collectively called \textit{arithmetic
 types}.

--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -56,12 +56,12 @@ template are \textit{vector types}. Vector lengths must be between 1 and 4 (i.e.
 \texttt{int32\_t}, and \texttt{int64\_t}. Each of the signed integer types is
 explicitly named for the size in bits of the type's object representation. There
 is also the type alias \texttt{int} which is an alias of \texttt{int32\_t}.
-There are two \textit{minimum precision signed integer types}:
-\texttt{min12int}, and \texttt{min16int}. Each of the minimum precision signed
-integer types are named for the required minimum value representation size in
-bits. The object representation of all minimum precision types is \texttt{int}.
-The standard signed integer types and minimum precision signed integer types are
-collectively called \textit{signed integer types}.
+There is one \textit{minimum precision signed integer type}: \texttt{min16int}.
+The minimum precision signed integer type is named for the required minimum
+value representation size in bits. The object representation of
+\texttt{min16int} is \texttt{int}. The standard signed integer types and minimum
+precision signed integer type are collectively called \textit{signed integer
+types}.
 
 \p There are three \textit{standard unsigned integer types}: \texttt{uint16\_t},
 \texttt{uint32\_t}, and \texttt{uint64\_t}. Each of the unsigned integer types
@@ -94,14 +94,13 @@ as controlled by implementation defined compiler settings. If \texttt{half} is
 otherwise it will have an object representation matching the \textbf{binary16}
 format defined in \gls{IEEE754}\footnote{IEEE-754 only defines a binary encoding
 for 16-bit floating point values, it does not fully specify the behavior of such
-types.}. There are two \textit{minimum precision floating point types}:
-\texttt{min10float}, and \texttt{min16float}. Each of the minimum precision
-floating point types are named for the required minimum value representation
-size in bits. The object representation of all minimum precision types is
-\texttt{float}\footnote{This means when stored to memory minimum precision types
-are stored as \textbf{binary32} as defined in \gls{IEEE754}.}. The standard
-floating point types and minimum precision floating point types are collectively
-called \textit{floating point types}.
+types.}. There is one \textit{minimum precision floating point type}:
+\texttt{min16float}. The minimum precision floating point type is named for the
+required minimum value representation size in bits. The object representation of
+\texttt{min16float} is \texttt{float}\footnote{This means when stored to memory
+objects of type \texttt{min16float} are stored as \textbf{binary32} as defined
+in \gls{IEEE754}.}. The standard floating point types and minimum precision
+floating point type are collectively called \textit{floating point types}.
 
 \p Integer and floating point types are collectively called \textit{arithmetic
 types}.

--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -75,11 +75,15 @@ precision types is \texttt{uint}. The standard unsigned integer types and
 minimum precision unsigned integer types are collectively called
 \textit{unsigned integer types}.
 
-\p The signed integer types and unsigned integer types are collectively called
-\textit{integer types}. Integer types inherit the object representation of
-integers defined in \glsdesc{isoC23}\footnote{C23 adopts two's compliment as the
-object representation for integer types.}. Integer types shall satisfy the
-constraints defined in \glsdesc{isoCPP}, section \textbf{basic.fundamental}.
+\p The minimum precision signed integer types and minimum precision unsigned
+integer types are collectively called \textit{minimum precision integer types}.
+The standard signed integer types and standard unsigned integer types are
+collectively called \textit{standard integer types}. The signed integer types
+and unsigned integer types are collectively called \textit{integer types}.
+Integer types inherit the object representation of integers defined in
+\glsdesc{isoC23}\footnote{C23 adopts two's compliment as the object
+representation for integer types.}. Integer types shall satisfy the constraints
+defined in \glsdesc{isoCPP}, section \textbf{basic.fundamental}.
 
 \p There are three \textit{standard floating point types}: \texttt{half},
 \texttt{float}, and \texttt{double}. The \texttt{float} type is a 32-bit

--- a/specs/language/conversions.tex
+++ b/specs/language/conversions.tex
@@ -159,6 +159,11 @@ to a higher conversion rank.
   corresponding signed integer type.
   \item The rank of \texttt{bool} shall be less than the rank of all other
   standard integer types.
+  \item The rank of a minimum precision integer type shall be less than the rank
+  of any other minimum precision integer type with a larger minimum value
+  representation size.
+  \item The rank of a minimum precision integer type shall be less than the rank
+  of all standard integer types.
   \item For all integer types \texttt{T1}, \texttt{T2}, and \texttt{T3}: if
   \texttt{T1} has greater rank than \texttt{T2} and \texttt{T2} has greater rank
   than \texttt{T3}, then \texttt{T1} shall have greater rank than \texttt{T3}.
@@ -172,6 +177,11 @@ to a higher conversion rank.
   \item The rank of a floating point type shall be greater than the rank of any
   floating point type with a smaller size.
   \item The rank \texttt{float} shall be greater than the rank of \texttt{half}.
+  \item The rank of a minimum precision floating point type shall be less than
+  the rank of any other minimum precision floating point type with a larger
+  minimum value representation size.
+  \item The rank of a minimum precision floating point type shall be less than
+  the rank of all standard floating point types.
   \item For all floating point types \texttt{T1}, \texttt{T2}, and \texttt{T3}:
   if \texttt{T1} has greater rank than \texttt{T2} and \texttt{T2} has greater
   rank than \texttt{T3}, then \texttt{T1} shall have greater rank than

--- a/specs/language/conversions.tex
+++ b/specs/language/conversions.tex
@@ -172,16 +172,9 @@ to a higher conversion rank.
 \Sub{Floating Point Conversion Rank}{Conv.rank.float}
 
 \begin{itemize}
-  \item No two floating point types shall have the same conversion rank even if
-  they have the same representation.
-  \item The rank of a floating point type shall be greater than the rank of any
-  floating point type with a smaller size.
+  \item The rank \texttt{half} shall be greater than the rank of \texttt{min16float}.
   \item The rank \texttt{float} shall be greater than the rank of \texttt{half}.
-  \item The rank of a minimum precision floating point type shall be less than
-  the rank of any other minimum precision floating point type with a larger
-  minimum value representation size.
-  \item The rank of a minimum precision floating point type shall be less than
-  the rank of all standard floating point types.
+  \item The rank \texttt{double} shall be greater than the rank of \texttt{float}.
   \item For all floating point types \texttt{T1}, \texttt{T2}, and \texttt{T3}:
   if \texttt{T1} has greater rank than \texttt{T2} and \texttt{T2} has greater
   rank than \texttt{T3}, then \texttt{T1} shall have greater rank than


### PR DESCRIPTION
This just updates the conversion rank for minimum precision types which are now represented in the Basic.types section.

I've iterated on this a few times and reduced it down to just the min16{int|uint|float} types because those are the only types DXC actually supports. Using any of the other types produces a warning and they get treated as the corresponding min16 type.

The promotion orders are as follows:

min16int < int16_t < int32_t < int64_t
min16uint < uint16_t < uint32_t < uint64_t
min16float < half < float < double