### PR TITLE
Fix error caused by missing endraw.

### DIFF
--- a/proposals/infra/INF-0003-packoffset.md
+++ b/proposals/infra/INF-0003-packoffset.md
@@ -169,3 +169,5 @@ metadata for cbuffer.
 
 How to support 16bit types.
 The offset like c0.y is 32bit.
+
+<!-- {% endraw %} -->


### PR DESCRIPTION
Added < !-- {% endraw %} -- > at the end.