### PR TITLE
Cleanup C++ references in the language spec

### DIFF
--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -77,7 +77,7 @@ minimum precision unsigned integer types are collectively called
 
 \p The signed integer types and unsigned integer types are collectively called
 \textit{integer types}. Integer types inherit the object representation of
-integers defined in \gls{isoC23}\footnote{C23 adopts two's compliment as the
+integers defined in \gls{isoC23}\footnote{C23 adopts two's complement as the
 object representation for integer types.}. Integer types shall satisfy the
 constraints defined in \gls{isoCPP}, section \textbf{basic.fundamental}.
 

--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -77,9 +77,9 @@ minimum precision unsigned integer types are collectively called
 
 \p The signed integer types and unsigned integer types are collectively called
 \textit{integer types}. Integer types inherit the object representation of
-integers defined in \glsdesc{isoC23}\footnote{C23 adopts two's compliment as the
+integers defined in \gls{isoC23}\footnote{C23 adopts two's compliment as the
 object representation for integer types.}. Integer types shall satisfy the
-constraints defined in \glsdesc{isoCPP}, section \textbf{basic.fundamental}.
+constraints defined in \gls{isoCPP}, section \textbf{basic.fundamental}.
 
 \p There are three \textit{standard floating point types}: \texttt{half},
 \texttt{float}, and \texttt{double}. The \texttt{float} type is a 32-bit

--- a/specs/language/glossary.tex
+++ b/specs/language/glossary.tex
@@ -26,20 +26,20 @@
 
 \newglossaryentry{isoC}
 {
-  name={ISO/IEC 9899:2018},
-  description={ISO C standard}
+  name={ISO C standard (2011)},
+  description={ISO/IEC 9899:2011: Standard for Programming Language C.}
 }
 
 \newglossaryentry{isoC23}
 {
-  name={ISO/IEC 9899:2023},
-  description={ISO C23 standard}
+  name={ISO C standard (2023)},
+  description={ISO/IEC 9899:2023: Standard for Programming Language C.}
 }
 
 \newglossaryentry{isoCPP}
 {
-  name={ISO/IEC 14882:2020},
-  description={ISO C++ standard}
+  name={ISO C++ standard (2011)},
+  description={ISO/IEC 14882:2011: Standard for Programming Language C++.}
 }
 
 \newglossaryentry{IEEE754}


### PR DESCRIPTION
This just cleans up the C++ references in the document. It includes the following changes:

* Made the name in the glossaries human readable rather than the ISO/IEC number, and included the year.
* Changed two places where \glsdesc was called to \gls
* Extended the description text to have the ISO/IEC number and full standard title.
* Formalize general C/C++ references to C11 and C++11.

With this change references from `\gls{...}` will expand to a readable name (e.g. "ISO C Standard (2011)") rather than the ISO/IEC number.

This change also makes general references to C and C++ (the isoC and isoCPP glossary entries) point to C11 and C++11 respectively. We still have an explicit reference to C23 for integer value behaviors (C23 adopted two's compliement).

The intent of basing on C11 and C++11 is that HLSL 202x is unlikely to support most C++ features beyond C++98, but C11 and C++11 contained a lot of improvements and clarifications in wording. Also C++11 features are highly requested, so HLSL 202y will almost certainly gain C++11 (and maybe later version) features.

I did not want to base on newer C++ because the differences between HLSL and C++17+ are substantial, so the benefit of citing a base specification is limited in those cases.

We should continue to cite newer specifictions by version explicitly where it is helpful.