### PR TITLE
Add table of contents to HTML generation

### DIFF
--- a/specs/language/CMakeLists.txt
+++ b/specs/language/CMakeLists.txt
@@ -48,7 +48,7 @@ add_custom_target(pdf
                   DEPENDS ${main_file} ${PROJECT_NAME}-prebuild ${PROJECT_NAME}-glossaries)
 
 add_custom_target(html
-                  COMMAND ${PANDOC_COMPILER} ${main_file} -f latex -t html -s -o ${CMAKE_BINARY_DIR}/html/hlsl.html
+                  COMMAND ${PANDOC_COMPILER} ${main_file} -f latex -t html --table-of-contents=true -s -o ${CMAKE_BINARY_DIR}/html/hlsl.html
                   COMMENT "Generating HTML"
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   DEPENDS ${main_file} ${PROJECT_NAME}-prebuild ${PROJECT_NAME}-glossaries ${PROJECT_NAME}-dirs)


### PR DESCRIPTION
This adds a trivial table of contents to the HTML spec build. It isn't pretty but it works.