### PR TITLE
Add Linkage section

### DIFF
--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -14,31 +14,33 @@
 
 \p The following entities in HLSL have \textit{external linkage}:
 \begin{itemize}
-    \item entry point functions
-    \item functions marked with \texttt{export} keyword
-    \item global variables that are not marked \texttt{static} or \texttt{groupshared} \footnote{These are not really linked with other translation units but rather their values are loaded indirectly based on cbuffer mapping.}
-    \item enumerations
-    \item classes or template classes, their member functions, static data members, nested classes and enumerations
+  \item entry point functions
+  \item functions marked with \texttt{export} keyword
+  \item global variables that are not marked \texttt{static} or \texttt{groupshared} \footnote{These are not really linked with other translation units but rather their values are loaded indirectly based on cbuffer mapping.}
+  \item static data members of classes or template classes
 \end{itemize}
 
 \p Linkage of functions (including template functions) that are not entry points or marked with \texttt{export} keyword is implementation dependent. \footnote{In DXC today functions that are not entry points or exported have \textit{internal linkage} by default. This can be overriden by \texttt{-default-linkage} compiler option.}
-    
+
 \Sub{Internal Linkage}{Decl.Linkage.Internal}
 
 \p Entities with \textit{internal linkage} can be referred to from all scopes in the current translation unit.
 
 \p The following entities in HLSL have \textit{internal linkage}:
 \begin{itemize}
-    \item global variables marked as \texttt{static} or \texttt{groupshared}
+  \item global variables marked as \texttt{static} or \texttt{groupshared}
+  \item all entities declared in an unnamed namespace or a namespace within an unnamed namespace
+  \item enumerations
+  \item classes or template classes, their member functions, and nested classes and enumerations
 \end{itemize}
 
 \Sub{No Linkage}{Decl.Linkage.NoLinkage}
 
 \p An entity with \textit{no linkage} can be referred to only from the scope it is in.
 
-\p Any of the following entites declared at block scope have no linkage:
+\p Any of the following entites declared at function scope or block scopes derived from function scope have no linkage:
 \begin{itemize}
   \item local variables
   \item local classes and their member functions
-  \item other names declared at block scope such as typedefs, enumerations, and enumerators.
+  \item other entities declared at function scope or block scopes derived from function scope that such as typedefs, enumerations, and enumerators
 \end{itemize}

--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -1,0 +1,8 @@
+\Ch{Declarations}{Decl}
+\Sec{Function Definitions}{Decl.Function}
+\Sub{Visibility and Linkage}{Decl.Function.Visibility}
+
+\p Functions have \textit{internal linkage} by default.
+
+\Sec{Attributes}{Decl.Attr}
+\Sub{Entry Attributes}{Decl.Attr.Entry}

--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -1,8 +1,45 @@
 \Ch{Declarations}{Decl}
 \Sec{Function Definitions}{Decl.Function}
-\Sub{Visibility and Linkage}{Decl.Function.Visibility}
-
-\p Functions have \textit{internal linkage} by default.
-
 \Sec{Attributes}{Decl.Attr}
 \Sub{Entry Attributes}{Decl.Attr.Entry}
+\Sec{Linkage}{Decl.Linkage}
+
+\p An entity that denotes an object, reference, function, type, template, namespace, or value, may have a \textit{linkage}. If a name has \textit{linkage}, it refers to the same entity as the same name introduced by a declaration in another scope. If a variable, function, or another entity with the same name is declared in several scopes, but does not have sufficient \textit{linkage}, then several instances of the entity are generated.
+
+\p There are three linkages recognized: \textit{external linkage}, \textit{internal linkage} and \textit{no linkage}.
+
+\Sub{External Linkage}{Decl.Linkage.External}
+
+\p Entities with \textit{external linkage} can be referred to from the scopes in the other translation units and enable linking between them.
+
+\p The following entities in HLSL have \textit{external linkage}:
+\begin{itemize}
+    \item entry point functions
+    \item functions marked with \texttt{export} keyword
+    \item global variables that are not marked \texttt{static} or \texttt{groupshared} \footnote{These are not really linked with other translation units but rather their values are loaded indirectly based on cbuffer mapping.}
+    \item enumerations
+    \item classes, their member functions, static data members, nested classes and enumerations
+    \item template classes not declared \texttt{static}
+\end{itemize}
+
+\p Linkage of functions (including template functions) that are not entry points or marked with \texttt{export} keyword is implementation dependent. \footnote{In DXC today functions that are not entry points or exported have \textit{internal linkage} by default. This can be overriden by \texttt{-default-linkage} compiler option.}
+    
+\Sub{Internal Linkage}{Decl.Linkage.Internal}
+
+\p Entities with \textit{internal linkage} can be referred to from all scopes in the current translation unit.
+
+\p The following entities in HLSL have \textit{internal linkage}:
+\begin{itemize}
+    \item global variables marked as \texttt{static} or \texttt{groupshared}
+\end{itemize}
+
+\Sub{No Linkage}{Decl.Linkage.NoLinkage}
+
+\p An entity with \textit{no linkage} can be referred to only from the scope it is in.
+
+\p Any of the following entites declared at block scope have no linkage:
+\begin{itemize}
+  \item local variables
+  \item local classes and their member functions
+  \item other names declared at block scope such as typedefs, enumerations, and enumerators.
+\end{itemize}

--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -18,8 +18,7 @@
     \item functions marked with \texttt{export} keyword
     \item global variables that are not marked \texttt{static} or \texttt{groupshared} \footnote{These are not really linked with other translation units but rather their values are loaded indirectly based on cbuffer mapping.}
     \item enumerations
-    \item classes, their member functions, static data members, nested classes and enumerations
-    \item template classes not declared \texttt{static}
+    \item classes or template classes, their member functions, static data members, nested classes and enumerations
 \end{itemize}
 
 \p Linkage of functions (including template functions) that are not entry points or marked with \texttt{export} keyword is implementation dependent. \footnote{In DXC today functions that are not entry points or exported have \textit{internal linkage} by default. This can be overriden by \texttt{-default-linkage} compiler option.}

--- a/specs/language/hlsl.tex
+++ b/specs/language/hlsl.tex
@@ -89,6 +89,8 @@
 \input{conversions}
 \input{expressions}
 \input{overloading}
+\input{statements}
+\input{declarations}
 
 \input{placeholders} % Declare placeholder references
 

--- a/specs/language/placeholders.tex
+++ b/specs/language/placeholders.tex
@@ -4,12 +4,6 @@
 % forward references can be inserted into the specification as it is being
 % written to force updating the references as they change.
 
-\Ch{Statements}{Stmt}
-\Sec{Label Statements}{Stmt.Label}
-\Ch{Declarations}{Decl}
-\Sec{Function Definitions}{Decl.Function}
-\Sec{Attributes}{Decl.Attr}
-\Sub{Entry Attributes}{Decl.Attr.Entry}
 \Ch{Classes}{Classes}
 \Sec{Static Members}{Classes.Static}
 \Sec{Conversions}{Classes.Conversions}

--- a/specs/language/statements.tex
+++ b/specs/language/statements.tex
@@ -1,0 +1,2 @@
+\Ch{Statements}{Stmt}
+\Sec{Label Statements}{Stmt.Label}


### PR DESCRIPTION
Create chapter file for Declarations and add section about linkage. Enumerate the language defaults and where it is implementation dependent. Add empty chapter file for Statements to preserve the chapter ordering.