### PR TITLE
Add "needs-triage" keyword to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: ['enhancement', 'needs-triage']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -2,7 +2,7 @@
 name: Proposal Follow-up
 about: Follow-up issue for a proposal
 title: ''
-labels: 'active proposal'
+labels: ['active proposal', 'needs-triage']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -2,7 +2,7 @@
 name: Spec
 about: Highlight a problem with a published spec or accepted proposal
 title: ''
-labels: 'spec'
+labels: ['spec', 'needs-triage']
 assignees: ''
 
 ---


### PR DESCRIPTION
This will get new issues automaticallly added to the triage board so I can stop doing it manually.