### PR TITLE
Simplify conversion sequences and overload scoring

### DIFF
--- a/specs/language/conversions.tex
+++ b/specs/language/conversions.tex
@@ -8,13 +8,11 @@ order:
   \item Zero or one conversion of either lvalue-to-rvalue, or array-to-pointer.
   \item Zero or one conversion of either integral conversion, floating point
   conversion, floating point-integral conversion, or boolean conversion,
-  derived-to-base-lvalue, vector splat, vector truncation. \footnote{This
-  differs from C++ with the addition of vector splat and truncation casting.}.
-  \item Zero or one conversion of either component-wise integral conversion,
-  component-wise floating point conversion, component-wise floating
-  point-integral conversion, or component-wise boolean
-  conversion\footnote{C++ does not support this conversion in the sequence for
-  component-wise conversion of vector and matrix types.}.
+  derived-to-base-lvalue, or flat conversion\footnote{This differs from C++ with
+  the addition of flat conversion.}.
+  \item Zero or one conversion of scalar-vector splat, or vector/matrix
+  truncation. \footnote{C++ does not support dimension altering conversions for
+  scalar, vector or matrix types.}.
   \item Zero or one qualification conversion.
 \end{enumerate}
 

--- a/specs/language/overloading.tex
+++ b/specs/language/overloading.tex
@@ -369,8 +369,4 @@ rules applies:
     \item conversion of \texttt{B} to \texttt{A} is better than conversion of
     \texttt{C} to \texttt{A}.
   \end{itemize}
-  \item If \(ICS(f)\) and \(ICS(f`')\) are both \textbf{Extension} or
-  \textbf{Truncation} ranked, the next highest ranked conversion in the
-  sequences are compared to disambiguate. If those conversions are of the same
-  rank, the sequences are ambiguous.
 \end{itemize}

--- a/specs/language/overloading.tex
+++ b/specs/language/overloading.tex
@@ -339,4 +339,8 @@ rules applies:
     \item conversion of \texttt{B} to \texttt{A} is better than conversion of
     \texttt{C} to \texttt{A}.
   \end{itemize}
+  \item If \(ICS(f)\) and \(ICS(f`')\) are both \textbf{Promotion} or
+  \textbf{Conversion} ranked, and \(ICS(f)\) contains an \textbf{Extension}
+  conversion, but \(ICS(f`')\) does not contain an \textbf{Extension},
+  \(ICS(f`')\) is the better conversion than \(ICS(f')\).
 \end{itemize}

--- a/specs/language/overloading.tex
+++ b/specs/language/overloading.tex
@@ -271,7 +271,7 @@ below:
           & \ref{Conv.array} \\ \cline{1-2}\cline{4-4}
     Qualification & Qualification Adjustment & & \ref{Conv.qual} \\ \cline{1-4}
 
-    Scalar splat & Scalar Extension & Extension
+    Scalar splat (without conversion) & Scalar Extension & Extension
           & \ref{Conv.vsplat} \\ \cline{1-4}
 
     Integral promotion & &
@@ -280,6 +280,9 @@ below:
           & \ref{Conv.fconv} \& \ref{Conv.rank.float} \\ \cline{1-1}\cline{4-4}
     Component-wise promotion &  &  & \ref{Conv.cwise} \\ \cline{1-4}
 
+    Scalar splat promotion & Scalar Extension Promotion & Promotion Extension
+          & \ref{Conv.vsplat} \\ \cline{1-4}
+
     Integral conversion & & & \ref{Conv.iconv} \\ \cline{1-1}\cline{4-4}
     Floating point conversion &  &  & \ref{Conv.fconv} \\ \cline{1-1}\cline{4-4}
     Floating-integral conversion & Conversion & Conversion
@@ -287,18 +290,46 @@ below:
     Boolean conversion &  &  & \ref{Conv.bool} \\ \cline{1-1}\cline{4-4}
     Component-wise conversion &  &  & \ref{Conv.cwise} \\ \cline{1-4}
 
-    Vector truncation & Dimensionality Reduction & Truncation
-          & \ref{Conv.vtrunc} \\ \cline{1-4}
+    Scalar splat conversion & Scalar Extension Conversion & Conversion Extension
+          & \ref{Conv.vsplat} \\ \cline{1-4}
+
+    Vector truncation (without conversion) & Dimensionality Reduction
+          & Truncation & \ref{Conv.vtrunc} \\ \cline{1-4}
+
+    Vector truncation promotion & Dimensionality Reduction Promotion
+          & Truncation Promotion  & \ref{Conv.vtrunc} \\ \cline{1-4}
+
+    Vector truncation conversion & Dimensionality Reduction Conversion
+          & Truncation Conversion & \ref{Conv.vtrunc} \\ \cline{1-4}
     \hline
   \end{tabular}
 \end{center}
 
-\p The rank of a conversion sequence is determined by considering the rank of
-each conversion. Conversion sequence ranks are ordered such that \textbf{Exact
-Match} rank is better than \textbf{Extension} rank, which is better than
-\textbf{Promotion} rank, which is better than \textbf{Conversion} rank, which is
-better than \textbf{Truncation} rank. The rank of a conversion sequence is the
-rank of the worst ranked conversion in the sequence.
+\p If a scalar splat conversion occurs in a conversion sequence where all other
+conversions are \textbf{Exact Match} rank, the conversion is ranked as
+\textbf{Extension}. If a scalar splat occurs in a conversion
+sequence with a \textbf{Promotion} conversion, the conversion is ranked as
+\textbf{Promotion Extension}. If a scalar splat occurs in a conversion
+sequence with a \textbf{Conversion} conversion, the conversion is ranked as
+\textbf{Conversion Extension}.
+
+\p If a vector truncation conversion occurs in a conversion sequence where all
+other conversions are \textbf{Exact Match} rank, the conversion is ranked as
+\textbf{Truncation}. If a vector truncation occurs in a conversion
+sequence with a \textbf{Promotion} conversion, the conversion is ranked as
+\textbf{Promotion Truncation}. If a vector truncation occurs in a conversion
+sequence with a \textbf{Conversion} conversion, the conversion is ranked as
+\textbf{Conversion Truncation}.
+
+\p Otherwise, the rank of a conversion sequence is determined by considering the
+rank of each conversion.
+
+\p Conversion sequence ranks are ordered such that \textbf{Exact
+Match} rank is better than \textbf{Exact Match Extension} rank, which is better
+than \textbf{Promotion} rank, which is better than \textbf{Extension} rank,
+which is better than \textbf{Conversion} rank, which is better than
+\textbf{Truncation} rank. The rank of a conversion sequence is the rank of the
+worst ranked conversion in the sequence.
 
 % TODO: Define user-defined conversion sequences. DXC doesn't actually support
 % these because we don't resolve overloads for user-defined conversion

--- a/specs/language/overloading.tex
+++ b/specs/language/overloading.tex
@@ -271,15 +271,14 @@ below:
           & \ref{Conv.array} \\ \cline{1-2}\cline{4-4}
     Qualification & Qualification Adjustment & & \ref{Conv.qual} \\ \cline{1-4}
 
-    Scalar splat & Scalar Extension & Extension
-          & \ref{Conv.vsplat} \\ \cline{1-4}
-
     Integral promotion & &
           & \ref{Conv.iconv} \& \ref{Conv.rank.int} \\ \cline{1-1}\cline{4-4}
     Floating point promotion & Promotion & Promotion
           & \ref{Conv.fconv} \& \ref{Conv.rank.float} \\ \cline{1-1}\cline{4-4}
     Component-wise promotion &  &  & \ref{Conv.cwise} \\ \cline{1-4}
 
+    Scalar splat & Scalar Extension & Extension
+          & \ref{Conv.vsplat} \\ \cline{1-4}
 
     Integral conversion & & & \ref{Conv.iconv} \\ \cline{1-1}\cline{4-4}
     Floating point conversion &  &  & \ref{Conv.fconv} \\ \cline{1-1}\cline{4-4}
@@ -339,8 +338,8 @@ rules applies:
     \item conversion of \texttt{B} to \texttt{A} is better than conversion of
     \texttt{C} to \texttt{A}.
   \end{itemize}
-  \item If \(ICS(f)\) and \(ICS(f`')\) are both \textbf{Promotion} or
-  \textbf{Conversion} ranked, and \(ICS(f)\) contains an \textbf{Extension}
-  conversion, but \(ICS(f`')\) does not contain an \textbf{Extension},
-  \(ICS(f`')\) is the better conversion than \(ICS(f')\).
+  \item If \(ICS(f)\) and \(ICS(f`')\) are both \textbf{Extension} or
+  \textbf{Truncation} ranked, the next highest ranked conversion in the
+  sequences are compared to disambiguate. If those conversions are of the same
+  rank, the sequences are ambiguous.
 \end{itemize}

--- a/specs/language/overloading.tex
+++ b/specs/language/overloading.tex
@@ -271,14 +271,14 @@ below:
           & \ref{Conv.array} \\ \cline{1-2}\cline{4-4}
     Qualification & Qualification Adjustment & & \ref{Conv.qual} \\ \cline{1-4}
 
+    Scalar splat & Scalar Extension & Extension
+          & \ref{Conv.vsplat} \\ \cline{1-4}
+
     Integral promotion & &
           & \ref{Conv.iconv} \& \ref{Conv.rank.int} \\ \cline{1-1}\cline{4-4}
     Floating point promotion & Promotion & Promotion
           & \ref{Conv.fconv} \& \ref{Conv.rank.float} \\ \cline{1-1}\cline{4-4}
     Component-wise promotion &  &  & \ref{Conv.cwise} \\ \cline{1-4}
-
-    Scalar splat & Scalar Extension & Extension
-          & \ref{Conv.vsplat} \\ \cline{1-4}
 
     Integral conversion & & & \ref{Conv.iconv} \\ \cline{1-1}\cline{4-4}
     Floating point conversion &  &  & \ref{Conv.fconv} \\ \cline{1-1}\cline{4-4}


### PR DESCRIPTION
This change is a shift in how conversion sequences and overload scoring
is handled to disambiguate a few cases that DXC handles today through
simpler rules.

The main cases relate to scoring conversion sequences with dimension
adjustment conversions. With this change an implicit conversion sequence
is now defined as:

* Value conversion (lvalue to rvalue or array decay)
* Data conversion (int/float/bool/struct promotion or conversion)
* Dimension conversion (splat or truncate)
* CV qualifier conversion (add const)

Conversion sequences are still assigned the rank of their "highest"
conversion following the same chart as before where the ranks are:

* Exact match
* Scalar extension without promotion or conversion
* Promotion
* Scalar extension with promotion
* Conversion
* Scalar extension with conversion
* Truncation without promotion or conversion
* Truncation with promotion
* Truncation with conversion

Given these rules:

ICS(float -> double) > ICS(float -> double3)
ICS(float -> double3) > ICS(float -> half)
ICS(float -> double2) == ICS(float -> dobule3)
ICS(float -> half) > ICS(float -> half3)
ICS(float4 -> double3) > ICS(float4 -> half3)
ICS(float4 -> double4) > ICS(float4 -> float2)
ICS(float4 -> half4) > ICS(float4 -> float2)

ICS(float -> double) > ICS(float -> float3)
ICS(float -> float3) > ICS(float -> double3)
ICS(float -> double4) > ICS(float -> half4)
ICS(float -> double4) != ICS(float -> double3)
ICS(double -> float4) != ICS(double -> float3)
ICS(double -> float4) != ICS(double -> half3)

ICS(float4 -> float3) > ICS(float4 -> double3)
ICS(float4 -> float3) > ICS(float4 -> half3)
ICS(float4 -> double3) > ICS(float4 -> half3)
ICS(double4 -> float3) != ICS(double4 ->half3)
ICS(half4 -> float3) != ICS(half4 ->double3)