### PR TITLE
Add `export` keyword to HLSL language spec

### DIFF
--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -1,13 +1,30 @@
 \Ch{Declarations}{Decl}
 \Sec{Preamble}{Decl.Pre}
+\p Declarations generally specify how names are to be interpreted. Declarations have the form
+\begin{grammar}
+  \define{declaration-seq}\br
+  \textit{declaration}\br
+  \textit{declaration-seq declaration}
+
+  \define{declaration}\br
+  \textit{name-declaration}\br
+  \textit{special-declaration}
+  
+  \define{name-declaration}\br
+  ...
+
+  \define{special-declaration}\br
+  \textit{export-declaration-group}\br
+  ...
+\end{grammar}
+
 \Sec{Specifiers}{Decl.Spec}
 \Sub{General}{Decl.Spec.General}
 \p The specifiers that can be used in a declaration are
 \begin{grammar}
   \define{decl-specifier}\br
-  \texttt{...}\br
   \textit{function-specifier}\br
-  \texttt{...}
+  ...
 \end{grammar}
 
 \Sub{Function specifiers}{Decl.Spec.Fct}
@@ -23,11 +40,30 @@
 
 \p The \texttt{export} specifier cannot be used on functions directly or indirectly within an unnamed namespace.
 
+\p Functions with \textit{external linkage} can also be specified in \textit{export-declaration-group} (\ref{Decl.Export}).
+
 \Sec{Declarators}{Decl.Decl}
 \Sec{Initializers}{Decl.Init}
 \Sec{Function Definitions}{Decl.Function}
 \Sec{Attributes}{Decl.Attr}
 \Sub{Entry Attributes}{Decl.Attr.Entry}
+
+\Sec{Export Declarations}{Decl.Export}
+
+\p One or more functions with \textit{external linkage} can be also specified in the form of
+
+\begin{grammar}
+  \define{export-declaration-group}\br
+  \texttt{export} \terminal{\{} \opt{function-declaration-seq} \terminal{\}}\br
+  
+  \define{function-declaration-seq}\br
+  \textit{function-declaration} \opt{function-declaration-seq}
+\end{grammar}
+
+\p The \texttt{export} specifier denotes that every \textit{function-declaration} included in \textit{function-declaration-seq} has \textit{external linkage} (\ref{Decl.Linkage.External}).
+
+\p The \textit{export-declaration-group} declaration cannot appear directly or indirectly within an unnamed namespace.
+
 \Sec{Linkage}{Decl.Linkage}
 
 \p An entity that denotes an object, reference, function, type, template, namespace, or value, may have a \textit{linkage}. If a name has \textit{linkage}, it refers to the same entity as the same name introduced by a declaration in another scope. If a variable, function, or another entity with the same name is declared in several scopes, but does not have sufficient \textit{linkage}, then several instances of the entity are generated.

--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -66,9 +66,9 @@
 
 \p The \textit{export-declaration-group} declaration cannot appear directly or indirectly within an unnamed namespace.
 
-\p Functions with \textit{external linkage} can also be decladed with an \texttt{export} specifier (\ref{Decl.Spec.Fct}).
+\p Functions with \textit{external linkage} can also be declared with an \texttt{export} specifier (\ref{Decl.Spec.Fct}).
 
-\p If a function is part of \textit{export-declaration-group} then all redeclarations of the same function must also be part on a \textit{export-declaration-group} or be declared with an \texttt{export} specifier (\ref{Decl.Spec.Fct}).
+\p If a function is part of an \textit{export-declaration-group} then all redeclarations of the same function must also be part on a \textit{export-declaration-group} or be declared with an \texttt{export} specifier (\ref{Decl.Spec.Fct}).
 
 \Sec{Linkage}{Decl.Linkage}
 

--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -1,4 +1,30 @@
 \Ch{Declarations}{Decl}
+\Sec{Preamble}{Decl.Pre}
+\Sec{Specifiers}{Decl.Spec}
+\Sub{General}{Decl.Spec.General}
+\p The specifiers that can be used in a declaration are
+\begin{grammar}
+  \define{decl-specifier}\br
+  \texttt{...}\br
+  \textit{function-specifier}\br
+  \texttt{...}
+\end{grammar}
+
+\Sub{Function specifiers}{Decl.Spec.Fct}
+
+\p A \textit{function-specifier} can be used only in a function declaration.
+
+\begin{grammar}
+  \define{function-specifier}\br
+  \texttt{export}\br
+\end{grammar}
+
+\p The \texttt{export} specifier denotes that the function has \textit{external linkage} (\ref{Decl.Linkage.External}).
+
+\p The \texttt{export} specifier cannot be used on functions directly or indirectly within an unnamed namespace.
+
+\Sec{Declarators}{Decl.Decl}
+\Sec{Initializers}{Decl.Init}
 \Sec{Function Definitions}{Decl.Function}
 \Sec{Attributes}{Decl.Attr}
 \Sub{Entry Attributes}{Decl.Attr.Entry}

--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -42,6 +42,8 @@
 
 \p Functions with \textit{external linkage} can also be specified in \textit{export-declaration-group} (\ref{Decl.Export}).
 
+\p If a function is declared with an \texttt{export} specifier then all redeclarations of the same function must also use the \texttt{export} specifier or be part of \textit{export-declaration-group} (\ref{Decl.Export}).
+
 \Sec{Declarators}{Decl.Decl}
 \Sec{Initializers}{Decl.Init}
 \Sec{Function Definitions}{Decl.Function}
@@ -63,6 +65,10 @@
 \p The \texttt{export} specifier denotes that every \textit{function-declaration} included in \textit{function-declaration-seq} has \textit{external linkage} (\ref{Decl.Linkage.External}).
 
 \p The \textit{export-declaration-group} declaration cannot appear directly or indirectly within an unnamed namespace.
+
+\p Functions with \textit{external linkage} can also be decladed with an \texttt{export} specifier (\ref{Decl.Spec.Fct}).
+
+\p If a function is part of \textit{export-declaration-group} then all redeclarations of the same function must also be part on a \textit{export-declaration-group} or be declared with an \texttt{export} specifier (\ref{Decl.Spec.Fct}).
 
 \Sec{Linkage}{Decl.Linkage}
 


### PR DESCRIPTION
Add `export` keyword to HLSL language specs.

The spec describes two ways the `export` keyword can be used.

1. On individual function declarations
```
export void f() {}
```
2. On a group of function declaration:
```
export {
   void f1();
   void f2() {}
}
```

DXC currently supports only the first case, but since Clang has support for both, we might as well support it in HLSL 202y too. 

This spec update does not yet include detailed rules for when a function can or cannot be exported, such as when it has resource argument or semantic annotations. That will be covered by llvm/llvm-project#93330.

This change also adds more sections under Declarations (based on C++ spec layout).

Contributes to: llvm/llvm-project#92812