### PR TITLE
[0011] Allows cap and ext attributes on variable declarations

### DIFF
--- a/proposals/0011-inline-spirv.md
+++ b/proposals/0011-inline-spirv.md
@@ -213,7 +213,12 @@ using VmeImageINTEL = vk::SpirvOpaqueType</* OpTypeVmeImageINTEL */ 5700, Imaget
 Then the user could simply use the types:
 
 ```
+[[vk::ext_capability(/* SubgroupAvcMotionEstimationINTEL */ 5696)]]
+[[vk::ext_extension("SPV_INTEL_device_side_avc_motion_estimation")]]
 VmeImageINTEL<Texture2D> image;
+
+[[vk::ext_capability(/* SubgroupAvcMotionEstimationINTEL */ 5696)]]
+[[vk::ext_extension("SPV_INTEL_device_side_avc_motion_estimation")]]
 AvcMcePayloadINTEL payload;
 ```
 
@@ -319,7 +324,31 @@ either an input or an output, not both.
 
 Existing inline SPIR-V has attributes to indicate that a capability or extension
 is needed by a particular part of the code. There are examples above. This
-proposal will allows these attribute to be applied to an entry point.
+proposal allows these attribute to be applied to an entry point.
+
+For types, the existing inline SPIR-V allows these attributes to be used on the
+function that was used to define the type. However, that function is no longer
+used when types are defined using `vk::SpirvType` and `vk::SpirvOpaqueType`. To
+be able to add the capabilities and extensions that are required for a type, we
+will allow these attributes to be used on variable and field declarations.
+
+The attributes will be able to be added to fields, so that they can be hidden in
+a header file.
+
+For example,
+
+```c++
+class Wrapper {
+
+  typedef vk::SpirvOpaqueType</* OpTypeAvcMcePayloadINTEL */ 5704> AvcMcePayloadINTEL;
+  [[vk::ext_capability(/* SubgroupAvcMotionEstimationINTEL */ 5696)]]
+  [[vk::ext_extension("SPV_INTEL_device_side_avc_motion_estimation")]]
+  AvcMcePayloadINTEL payload;
+};
+```
+
+In this case, the user of the header file, could use `Wrapper` without worrying
+about the capabilities and extensions.
 
 ## Detailed design
 

--- a/proposals/0011-inline-spirv.md
+++ b/proposals/0011-inline-spirv.md
@@ -158,20 +158,19 @@ test. Some of the difficulties are:
     manage.
 
 This proposal deprecates the old mechanism, and replaces it with two new types
-`vk::SpirvOpaqueType<uint OpCode, typename... Operands>` and `vk::SpirvType<uint
-OpCode, uint size, uint alignment, typename... Operands>`. For
-`SpirvOpaqueType`, the template on the type contains the opcode and all of the
-parameters necessary for that opcode. Each parameter must be one of three kinds
-of values:
+`vk::SpirvOpaqueType<uint OpCode, typename... Operands>` and
+`vk::SpirvType<uint OpCode, uint size, uint alignment, typename... Operands>`.
+For `SpirvOpaqueType`, the template on the type contains the opcode and all of
+the parameters necessary for that opcode. Each parameter must be one of three
+kinds of values:
 
 1.  An instantiation of the `vk::integral_constant<typename T, T v>` type
     template. This can be used to pass in any constant integral value. This
     value will be passed in to the type-declaration instruction as the id of an
     `OpConstant*` instruction.
 
-    For example, `123` can be passed in by using `vk::integral_constant<uint,
-    123>`.
-
+    For example, `123` can be passed in by using
+    `vk::integral_constant<uint, 123>`.
 1.  An instantiation of the `vk::Literal<typename T>` type template. `T` should
     be an instantiation of `integral_constant`. The value of this constant will
     be passed in to the type-declaration instruction as an immediate literal
@@ -183,18 +182,17 @@ of values:
 1.  Any type. The id of the lowered type will be passed in to the
     type-declaration instruction.
 
-For example,
-[`OpTypeArray`](https://registry.khronos.org/SPIR-V/specs/unified1/ SPIRV.html#OpTypeArray)
-takes an id for the element type and an id for the element length, so an array
-of 16 integers could be declared as
+For example, [`OpTypeArray`](https://registry.khronos.org/SPIR-V/specs/unified1/
+SPIRV.html#OpTypeArray) takes an id for the element type and an id for the
+element length, so an array of 16 integers could be declared as
 
 ```
 vk::SpirvOpaqueType</* OpTypeArray */ 28, int, vk::integral_constant<uint, 16> >
 ```
 
-[`OpTypeVector`](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html# OpTypeVector)
-takes an id for the component type and a literal for the component count, so a
-4-integer vector could be declared as
+[`OpTypeVector`](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#
+OpTypeVector) takes an id for the component type and a literal for the component
+count, so a 4-integer vector could be declared as
 
 ```
 vk::SpirvOpaqueType</* OpTypeVector */ 23, int, vk::Literal<vk::integral_constant<uint, 4> > >
@@ -211,8 +209,6 @@ you could have
 typedef vk::SpirvOpaqueType</* OpTypeAvcMcePayloadINTEL */ 5704> AvcMcePayloadINTEL;
 
 // Requires HLSL2021
-[[vk::ext_capability(/* SubgroupAvcMotionEstimationINTEL */ 5696)]]
-[[vk::ext_extension("SPV_INTEL_device_side_avc_motion_estimation")]]
 template<typename ImageType>
 using VmeImageINTEL
 [[vk::ext_capability(/* SubgroupAvcMotionEstimationINTEL */ 5696)]]


### PR DESCRIPTION
To be able to add the necessary capabilities and extensions for
SpirvTypes, we have to be able to add the capabilities and extension
attributes to the variables of that type. This change updates the inline
spirv spec to allows those changes.

Fixes #269 
