### PR TITLE
[Editorial] Move Decl.Linkage to Basic.Linkage

### DIFF
--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -115,6 +115,69 @@ tbuffer TB {                 // does not declare TB
 }
 \end{HLSL}
 
+\Sec{Linkage}{Basic.Linkage}
+
+\p An entity that denotes an object, reference, function, type, template,
+namespace, or value, may have a \textit{linkage}. If a name has
+\textit{linkage}, it refers to the same entity as the same name introduced by a
+declaration in another scope. If a variable, function, or another entity with
+the same name is declared in several scopes, but does not have sufficient
+\textit{linkage}, then several instances of the entity are generated.
+
+\p There are three linkages recognized: \textit{external linkage},
+\textit{internal linkage} and \textit{no linkage}.
+
+\Sub{External Linkage}{Basic.Linkage.External}
+
+\p Entities with \textit{external linkage} can be referred to from the scopes in
+the other translation units and enable linking between them.
+
+\p The following entities in HLSL have \textit{external linkage}:
+\begin{itemize}
+  \item entry point functions
+  \item functions marked with \texttt{export} keyword
+  \item global variables that are not marked \texttt{static} or
+  \texttt{groupshared} \footnote{These are not really linked with other
+  translation units but rather their values are loaded indirectly based on
+  cbuffer mapping.}
+  \item static data members of classes or template classes
+\end{itemize}
+
+\p Linkage of functions (including template functions) that are not entry points
+or marked with \texttt{export} keyword is implementation dependent. \footnote{In
+DXC today functions that are not entry points or exported have \textit{internal
+linkage} by default. This can be overriden by \texttt{-default-linkage} compiler
+option.}
+
+\Sub{Internal Linkage}{Basic.Linkage.Internal}
+
+\p Entities with \textit{internal linkage} can be referred to from all scopes in
+the current translation unit.
+
+\p The following entities in HLSL have \textit{internal linkage}:
+\begin{itemize}
+  \item global variables marked as \texttt{static} or \texttt{groupshared}
+  \item all entities declared in an unnamed namespace or a namespace within an
+  unnamed namespace
+  \item enumerations
+  \item classes or template classes, their member functions, and nested classes
+  and enumerations
+\end{itemize}
+
+\Sub{No Linkage}{Basic.Linkage.NoLinkage}
+
+\p An entity with \textit{no linkage} can be referred to only from the scope it
+is in.
+
+\p Any of the following entites declared at function scope or block scopes
+derived from function scope have no linkage:
+\begin{itemize}
+  \item local variables
+  \item local classes and their member functions
+  \item other entities declared at function scope or block scopes derived from
+  function scope that such as typedefs, enumerations, and enumerators
+\end{itemize}
+
 \Sec{Types}{Basic.types}
 
 \p The \textit{object representation} of an object of type \texttt{T} is the

--- a/specs/language/declarations.tex
+++ b/specs/language/declarations.tex
@@ -9,7 +9,7 @@
   \define{declaration}\br
   \textit{name-declaration}\br
   \textit{special-declaration}
-  
+
   \define{name-declaration}\br
   ...
 
@@ -36,7 +36,7 @@
   \texttt{export}\br
 \end{grammar}
 
-\p The \texttt{export} specifier denotes that the function has \textit{external linkage} (\ref{Decl.Linkage.External}).
+\p The \texttt{export} specifier denotes that the function has \textit{external linkage} (\ref{Basic.Linkage.External}).
 
 \p The \texttt{export} specifier cannot be used on functions directly or indirectly within an unnamed namespace.
 
@@ -57,58 +57,15 @@
 \begin{grammar}
   \define{export-declaration-group}\br
   \texttt{export} \terminal{\{} \opt{function-declaration-seq} \terminal{\}}\br
-  
+
   \define{function-declaration-seq}\br
   \textit{function-declaration} \opt{function-declaration-seq}
 \end{grammar}
 
-\p The \texttt{export} specifier denotes that every \textit{function-declaration} included in \textit{function-declaration-seq} has \textit{external linkage} (\ref{Decl.Linkage.External}).
+\p The \texttt{export} specifier denotes that every \textit{function-declaration} included in \textit{function-declaration-seq} has \textit{external linkage} (\ref{Basic.Linkage.External}).
 
 \p The \textit{export-declaration-group} declaration cannot appear directly or indirectly within an unnamed namespace.
 
 \p Functions with \textit{external linkage} can also be declared with an \texttt{export} specifier (\ref{Decl.Spec.Fct}).
 
 \p If a function is part of an \textit{export-declaration-group} then all redeclarations of the same function must also be part on a \textit{export-declaration-group} or be declared with an \texttt{export} specifier (\ref{Decl.Spec.Fct}).
-
-\Sec{Linkage}{Decl.Linkage}
-
-\p An entity that denotes an object, reference, function, type, template, namespace, or value, may have a \textit{linkage}. If a name has \textit{linkage}, it refers to the same entity as the same name introduced by a declaration in another scope. If a variable, function, or another entity with the same name is declared in several scopes, but does not have sufficient \textit{linkage}, then several instances of the entity are generated.
-
-\p There are three linkages recognized: \textit{external linkage}, \textit{internal linkage} and \textit{no linkage}.
-
-\Sub{External Linkage}{Decl.Linkage.External}
-
-\p Entities with \textit{external linkage} can be referred to from the scopes in the other translation units and enable linking between them.
-
-\p The following entities in HLSL have \textit{external linkage}:
-\begin{itemize}
-  \item entry point functions
-  \item functions marked with \texttt{export} keyword
-  \item global variables that are not marked \texttt{static} or \texttt{groupshared} \footnote{These are not really linked with other translation units but rather their values are loaded indirectly based on cbuffer mapping.}
-  \item static data members of classes or template classes
-\end{itemize}
-
-\p Linkage of functions (including template functions) that are not entry points or marked with \texttt{export} keyword is implementation dependent. \footnote{In DXC today functions that are not entry points or exported have \textit{internal linkage} by default. This can be overriden by \texttt{-default-linkage} compiler option.}
-
-\Sub{Internal Linkage}{Decl.Linkage.Internal}
-
-\p Entities with \textit{internal linkage} can be referred to from all scopes in the current translation unit.
-
-\p The following entities in HLSL have \textit{internal linkage}:
-\begin{itemize}
-  \item global variables marked as \texttt{static} or \texttt{groupshared}
-  \item all entities declared in an unnamed namespace or a namespace within an unnamed namespace
-  \item enumerations
-  \item classes or template classes, their member functions, and nested classes and enumerations
-\end{itemize}
-
-\Sub{No Linkage}{Decl.Linkage.NoLinkage}
-
-\p An entity with \textit{no linkage} can be referred to only from the scope it is in.
-
-\p Any of the following entites declared at function scope or block scopes derived from function scope have no linkage:
-\begin{itemize}
-  \item local variables
-  \item local classes and their member functions
-  \item other entities declared at function scope or block scopes derived from function scope that such as typedefs, enumerations, and enumerators
-\end{itemize}


### PR DESCRIPTION
This is purely an editorial re-ordering. No changes in language just moving the section from Decl earlier to Basic so that other concepts in basic for specifying the program model will flow more naturally.