### PR TITLE
Add scalar layout compatability trait

### DIFF
--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -289,6 +289,37 @@ completed. The \texttt{void} type is used to signify the return type of a
 function that returns no value. Any expression can be explicitly converted to
 \texttt{void}.
 
+\Sub{Scalarized Type Compatability}{Basic.types.scalarized}
+
+\p All types \texttt{T} have a \textit{scalarized representation}, \(SR(T)\),
+which is a list of one or more types representing each scalar element of
+\texttt{T}.
+
+\p Scalarized representations are determined as follows:
+\begin{itemize}
+\item The scalarized representation of an array \texttt{T[n]} is \(SR(T_0), ..
+SR(T_n)\).
+
+\item The scalarized representation of a vector \texttt{vector<T,n>} is \(SR(T_0),
+.. SR(T_n)\).
+
+\item The scalarized representation of a class type \texttt{T}, \(SR(T)\) is
+computed recursively as \(SR(T::base), SR(T::_0), .. SR(T::_n)\) where
+\texttt(T::base) is \texttt{T}'s base class if it has one, and \(T::_n\)
+represents the \textit{n} non-static members of \texttt{T}.
+
+\item The scalarized representation for an enumeration type is the underlying
+arithmetic type.
+
+\item The scalarized representation for arithmetic, intangible types, and any other
+type \texttt{T} is \(T\).
+\end{itemize}
+
+\p Two types \textit{cv1} \texttt{T1} and \textit{cv2} \texttt{T2} are
+\textit{scalar-layout-compatible types} if \texttt{T1} and \texttt{T2} are the same
+type or if the sequence of types defined by the scalar representation \(SR(T1)\)
+and scalar representation \(SR(T2)\) are identical.
+
 \Sec{Lvalues and rvalues}{Basic.lval}
 
 \p Expressions are classified by the type(s) of values they produce. The valid

--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -228,6 +228,10 @@ be defined to have an \textit{incomplete} type.
 template are \textit{vector types}. Vector lengths must be between 1 and 4 (i.e.
 \( 1 \leq N \leq 4 \) ).
 
+\p Matrices of scalar types declared with the built-in \texttt{matrix<T,N,M>}
+template are \textit{matrix types}. Matrix dimensions, \texttt{N} and
+\texttt{M}, must be between 1 and 4 (i.e. \( 1 \leq N \leq 4 \) ).
+
 \Sub{Arithmetic Types}{Basic.types.arithmetic}
 
 \p There are three \textit{standard signed integer types}: \texttt{int16\_t},
@@ -300,8 +304,11 @@ which is a list of one or more types representing each scalar element of
 \item The scalarized representation of an array \texttt{T[n]} is \(SR(T_0), ..
 SR(T_n)\).
 
-\item The scalarized representation of a vector \texttt{vector<T,n>} is \(SR(T_0),
-.. SR(T_n)\).
+\item The scalarized representation of a vector \texttt{vector<T,n>} is \(T_0,
+.. T_n\).
+
+\item The scalarized representation of a matrix \texttt{matrix<T,n, m>} is
+\(T_0, .. T_{n \times m}\).
 
 \item The scalarized representation of a class type \texttt{T}, \(SR(T)\) is
 computed recursively as \(SR(T::base), SR(T::_0), .. SR(T::_n)\) where


### PR DESCRIPTION
This adds language for determining if two types are _scalar layout compatible_ by defining a _scalarized representation_ which is a sequence of types that can then be compared.

The scalar representations of types will be used in several contexts throughout HLSL including:
* "Flattened" type casting
* Scalarized initiailization lists
* Defining additional type traits (homogeneous types)