### PR TITLE
Clarifications and alignment of vector truncations

### DIFF
--- a/specs/language/conversions.tex
+++ b/specs/language/conversions.tex
@@ -142,7 +142,7 @@ smaller dimensions or to scalar values by dropping trailing elements.
 \end{itemize}
 
 \p The resulting value of vector truncation is comprised of elements \( [0..y)
-\), dropping elements \( [y+1..x) \).
+\), dropping elements \( [y..x) \).
 
 \p A prvalue of type \texttt{matrix<T,x,y>} can be converted to a prvalue of
 type:

--- a/specs/language/conversions.tex
+++ b/specs/language/conversions.tex
@@ -132,18 +132,36 @@ value replicated into each element of the destination.
 
 \Sec{Vector and matrix truncation conversion}{Conv.vtrunc}
 
-\p A glvalue of type \texttt{vector<T,x>} can be converted to a cxvalue of type
-\texttt{vector<T,y>}, or a prvalue of type \texttt{vector<T,x>} can be converted
-to a prvalue of type \texttt{vector<T,y>} only if \( y < x \). The resulting
-value is comprised of elements \( [0..y) \), dropping elements [y+1..x).
+\p Matrix and vector types can be converted to matrix or vector types with
+smaller dimensions or to scalar values by dropping trailing elements.
 
-\p A glvalue of type \texttt{matrix<T,x,y>} can be converted to a cxvalue of type
-\texttt{matrix<T,z,w>}, or a prvalue of type \texttt{matrix<T,x,y>} can be
-converted to a prvalue of type \texttt{matrix<T,z,w>} only if \( x \leq z \)
-and \(y \leq w \). Matrix truncation is performed on each row and column
-dimension separately. The resulting value is comprised of vectors \( [0..z) \)
-which are each separately comprised of elements \( [0..w) \). Trailing vectors
-and elements are dropped.
+\p A prvalue of type \texttt{vector<T,x>} can be converted to a prvalue of type:
+\begin{itemize}
+\item \texttt{vector<T,y>} only if \( y < x \), or
+\item type \texttt{T}
+\end{itemize}
+
+\p The resulting value of vector truncation is comprised of elements \( [0..y)
+\), dropping elements \( [y+1..x) \).
+
+\p A prvalue of type \texttt{matrix<T,x,y>} can be converted to a prvalue of
+type:
+\begin{itemize}
+  \item \texttt{matrix<T,z,w>} only if \( x \leq z \) and \(y \leq w \),
+  \item \texttt{vector<T,z>} only if \( x \leq z \), or
+  \item \texttt{T}.
+\end{itemize}
+
+\p Matrix truncation is performed on each row and column dimension separately.
+The resulting value is comprised of vectors \( [0..z) \) which are each
+separately comprised of elements \( [0..w) \). Trailing vectors and elements are
+dropped.
+
+\p Reducing the dimension of a vector to one (\texttt{vector<T,1>}), can produce
+either a single element vector or a scalar of type \texttt{T}. Reducing the
+rows of a matrix to one (\texttt{matrix<T,x,1>}), can produce either a single
+row matrix, a vector of type \texttt{vector<T,x>}, or a scalar of type
+\texttt{T}.
 
 \Sec{Component-wise conversions}{Conv.cwise}
 

--- a/specs/language/conversions.tex
+++ b/specs/language/conversions.tex
@@ -132,13 +132,10 @@ value replicated into each element of the destination.
 
 \Sec{Vector and matrix truncation conversion}{Conv.vtrunc}
 
-\p Matrix and vector types can be converted to matrix or vector types with
-smaller dimensions or to scalar values by dropping trailing elements.
-
 \p A prvalue of type \texttt{vector<T,x>} can be converted to a prvalue of type:
 \begin{itemize}
 \item \texttt{vector<T,y>} only if \( y < x \), or
-\item type \texttt{T}
+\item \texttt{T}
 \end{itemize}
 
 \p The resulting value of vector truncation is comprised of elements \( [0..y)

--- a/specs/language/conversions.tex
+++ b/specs/language/conversions.tex
@@ -147,8 +147,8 @@ smaller dimensions or to scalar values by dropping trailing elements.
 \p A prvalue of type \texttt{matrix<T,x,y>} can be converted to a prvalue of
 type:
 \begin{itemize}
-  \item \texttt{matrix<T,z,w>} only if \( x \leq z \) and \(y \leq w \),
-  \item \texttt{vector<T,z>} only if \( x \leq z \), or
+  \item \texttt{matrix<T,z,w>} only if \( x \geq z \) and \(y \geq w \),
+  \item \texttt{vector<T,z>} only if \( x \geq z \), or
   \item \texttt{T}.
 \end{itemize}
 


### PR DESCRIPTION
Previously the spec had allowed trunction conversions to produce cxvalues which enabled them to be used in output arguments. This is inconsistent with the DXC and FXC implementation, which disallows binding trunctions to output arguments.

The spec also previously did not allow trunction to scalar values. Initially that was excluded due to discussions around truncations and extensions of output arguments. Since DXC and FXC both disallow trunction in output arguments, it seems safe to support truncation to scalar here with a cooresponding warning.

This will allow the spec to more consistently align with the reference implementations.

This has no change to overload resolution except that a vector argument can be truncated to a scalar producing a Truncation, Truncation Promotion, or Truncation Conversion implicit conversion sequence.: