### PR TITLE
Move the Overloading chapter later

### DIFF
--- a/specs/language/hlsl.tex
+++ b/specs/language/hlsl.tex
@@ -88,9 +88,9 @@
 \input{basic}
 \input{conversions}
 \input{expressions}
-\input{overloading}
 \input{statements}
 \input{declarations}
+\input{overloading}
 
 \input{placeholders} % Declare placeholder references
 


### PR DESCRIPTION
Having overloading before declarations was wrong. This just moves the chapter later.