### PR TITLE
[0010] Fix constructor call

### DIFF
--- a/proposals/0010-vk-buffer-ref.md
+++ b/proposals/0010-vk-buffer-ref.md
@@ -197,7 +197,7 @@ struct TestPushConstant_t
 
 float4 MainPs(void) : SV_Target0
 {
-      block_p g_p(g_PushConstants.root);
+      block_p g_p = block_p(g_PushConstants.root);
       g_p = g_p.Get().next;
       if ((uint64_t)g_pi == 0) // Null pointer test
           return float4(0.0,0.0,0.0,0.0);


### PR DESCRIPTION
The sample uses an invalid syntax for initializing a vk::BufferPointer.
This fixes up the syntax.

Fixes #322.
