### PR TITLE
Add GitHub action to label proposal PRs

### DIFF
--- a/.github/pr-labels.yml
+++ b/.github/pr-labels.yml
@@ -1,0 +1,2 @@
+needs-triage:
+  - proposals/**/*

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+          configuration-path: .github/prs-labels.yml


### PR DESCRIPTION
This adds `needs-triage` to any PR that changes the proposals folder, which will cause it to appear on our triage board.