### PR TITLE
Add resource chapter documenting buffers and bindings

### DIFF
--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -161,8 +161,10 @@ as the same non-parenthesized expression.
 
 \p A \textit{postfix-expression} followed by an expression in square brackets
 (\texttt{[ ]}) is a subscript expression. In an array subscript expression of
-the form \texttt{E1[E2]}, \texttt{E1} must either be a variable of array of
-\texttt{T[]}, or an object of type \texttt{T} where \texttt{T} provides an
+the form \texttt{E1[E2]}, \texttt{E1} must either be a variable of array,
+vector, matrix, typed buffer (\ref{Resources.tybuf}), or structured buffer
+(\ref{Resources.stbufs}), with elements of type \texttt{T[]} or an
+object of type \texttt{T} where \texttt{T} provides an
 overloaded implementation of \texttt{operator[]} (\ref{Overload}).\footnote{HLSL
 does not support the base address of a subscript operator being the expression
 inside the braces, which is valid in C and C++.}

--- a/specs/language/hlsl.tex
+++ b/specs/language/hlsl.tex
@@ -91,6 +91,7 @@
 \input{statements}
 \input{declarations}
 \input{overloading}
+\input{resources}
 
 \input{placeholders} % Declare placeholder references
 

--- a/specs/language/resources.tex
+++ b/specs/language/resources.tex
@@ -1,0 +1,943 @@
+\Ch{Resource Types}{Resources}
+
+Resources are built-in intangible types representing memory with an external interface.
+
+These take the form of Typed Buffers, Raw Buffers, Textures, and Samplers.
+Buffer and Texture types can be read-only or writable.
+Read-only buffers and textures types constitute Shader Resource Views (SRVs) of the external memory.
+Writable buffers and textures types constitute Unordered Access Views (UAVs) of the external memory.
+
+\Sec{Typed Buffers}{Resources.tybuf}
+
+The typed buffer class template represents a resource whose format can be converted upon load.
+
+Template types can be any type that totals or can be padded to 16 bytes.
+
+All typed buffers can be read through subscript operators or Load methods.
+Writable typed buffers can be written through subscript operators.
+
+Typed Buffers are declared with the built-in templates:
+
+Where \texttt{T} can be any arithmetic type \ref{Basic.types.arithmetic}
+or a vector with a maximum of four elements containing such an arithmetic type.
+The total size of a single contained element must be less than 16 bytes.
+
+Typed buffers perform format conversions on load such that the underlying data
+gets converted to the destination type.
+
+\Sec{Read-only Typed Buffers}{Resources.rotybufs}
+
+\begin{HLSL}
+template <typename T = float4>
+ class Buffer {
+   Buffer();
+   Buffer operator=(Buffer buf);
+
+   void GetDimensions(out uint width);
+
+   // element access
+   T operator[](uint pos);
+   T Load(in int pos);
+   T Load(in int pos, out uint status);
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.rotybufs.ctrs}
+
+Buffers can be defined with explicit or implicit template parameter types.
+\begin{HLSL}
+  Buffer buf1;
+  Buffer<> buf2;
+  Buffer<float4> buf3;
+\end{HLSL}
+Since \texttt{float4} is the default type, all of these definitions are equivalent.
+
+When defined at global scope, Buffers are bound to externally-defined backing stores
+using the explicit binding location if provided or the implicit binding if not.
+
+When defined at local scope, Buffers represent local references
+that can be associated with global buffers when assigned,
+but must be resolvable to a unique global buffer.
+
+\begin{HLSL}
+  Buffer<int> gbuf;
+  void doit() {
+    Buffer lbuf<int> = gbuf;
+  }
+\end{HLSL}
+Buffer operands to the assignment operator must have the same element type.
+
+\Sub{Dimensions}{Resources.rotybufs.dims}
+
+The size of a Buffer can be retrieved using the \texttt{GetDimensions} method.
+\begin{HLSL}
+void GetDimensions(out uint size);
+\end{HLSL}
+
+This returns the full size of the buffer in bytes through the \texttt{width} out parameter.
+
+\Sub{Element Access}{Resources.rotybufs.access}
+
+The contents of Buffers can be retrieved using the \texttt{Load} methods
+or the subscript operator.
+
+\begin{HLSL}
+ T Load(in int pos);
+ T operator[](uint pos);
+\end{HLSL}
+
+These each return the element at the given position \texttt{pos} of the type specified in the buffer definition.
+
+An additional \texttt{Load} method returns the indicated element just as the other,
+but also takes a second \texttt{status} parameter that returns information about the accessed resource.
+\begin{HLSL}
+ T Load(in int pos, out uint status);
+\end{HLSL}
+
+The \texttt{status} parameter returns an indication of whether the value retrieved accessed a mapped tile
+resource on tile-based platforms. This parameter is interpretted using the \texttt{CheckAccessFullyMapped}
+built-in function. If tiled resources are enabled, it returns true if the value was accessed from a mapped
+tile resource and false otherwise. If tiled resourced are not enabled, it will return true.
+
+\Sec{Writable Typed Buffers}{Resources.rwtybufs}
+
+\begin{HLSL}
+template <typename T>
+ class RWBuffer {
+
+   RWBuffer();
+   RWBuffer operator=(RWBuffer buf);
+
+   void GetDimensions(out uint size);
+
+   // element access
+   T operator[](uint n);
+   T Load(in int pos);
+   T Load(in int pos, out uint status);
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.rwtybufs.ctrs}
+
+RWBuffers must be defined with explicit template parameter types.
+\begin{HLSL}
+  RWBuffer<float4> buf;
+\end{HLSL}
+
+When defined at global scope, RWBuffers are bound to externally-defined backing stores
+using the explicit binding location if provided or the implicit binding if not.
+
+When defined at local scope, RWBuffers represent local references
+that can be associated with global buffers when assigned,
+but must be resolvable to a unique global buffer.
+
+\begin{HLSL}
+  RWBuffer<int> gbuf;
+  void doit() {
+    RWBuffer lbuf<int> = gbuf;
+  }
+\end{HLSL}
+RWBuffer operands to the assignment operator must have the same element type.
+
+\Sub{Dimensions}{Resources.rwtybufs.dims}
+
+The size of a RWBuffer can be retrieved using the \texttt{GetDimensions} method.
+\begin{HLSL}
+void GetDimensions(out uint size);
+\end{HLSL}
+
+This returns the full size of the buffer in bytes through the \texttt{width} out parameter.
+
+\Sub{Element Access}{Resources.rwtybufs.access}
+
+The contents of RWBuffers can be retrieved using the \texttt{Load} methods
+or the subscript operator.
+
+\begin{HLSL}
+ T Load(in int pos);
+ T operator[](uint pos);
+\end{HLSL}
+
+These each return the element at the given position \texttt{pos} of the type specified in the buffer definition.
+
+An additional \texttt{Load} method returns the indicated element just as the other,
+but also takes a second \texttt{status} parameter that returns information about the accessed resource.
+\begin{HLSL}
+ T Load(in int pos, out uint status);
+\end{HLSL}
+
+The \texttt{status} parameter returns an indication of whether the value retrieved accessed a mapped tile
+resource on tile-based platforms. This parameter is interpretted using the \texttt{CheckAccessFullyMapped}
+built-in function. If tiled resources are enabled, it returns true if the value was accessed from a mapped
+tile resource and false otherwise. If tiled resourced are not enabled, it will return true.
+
+Writable buffers have an additional subscript operator that allows assignment to an element of the buffer.
+It behaves as if it returns a reference to that element.
+\begin{HLSL}
+ T &operator[](uint pos);
+\end{HLSL}
+
+\Sec{Raw Buffer Types}{Resources.rawbufs}
+
+Raw buffers are either ByteAddressBuffers or StructuredBuffers.
+ByteAddressBuffers enable per-byte access to the raw data while
+StructuredBuffers have an associated structure type that determines how they are
+indexed. This type can be a scalar, vector, matrix, or user-defined struct.
+
+but partial writes aren't allowed.
+Though structured buffers can contain vectors,
+assignment to individual vector elements will result in an error.
+I HAVE BEEN UNABLE TO VERIFY THIS, THOUGH I WAS SURE IT WAS TRUE!
+
+\Sec{Read-only Byte Access Buffers}{Resources.robabufs}
+
+\begin{HLSL}
+ class ByteAddressBuffer {
+
+   ByteAddressBuffer();
+   ByteAddressBuffer operator=(ByteAddressBuffer buf);
+
+   void GetDimensions(out uint size);
+
+   // element access
+   uint Load(in uint byteOffset)
+   uint2 Load2(in uint byteOffset)
+   uint3 Load3(in uint byteOffset)
+   uint4 Load4(in uint byteOffset)
+   template<typename T>
+   T Load(in uint byteOffset);
+
+   uint Load(in uint byteOffset, out uint status)
+   uint2 Load2(in uint byteOffset, out uint status)
+   uint3 Load3(in uint byteOffset, out uint status)
+   uint4 Load4(in uint byteOffset, out uint status)
+   template<typename T>
+   T Load(in uint byteOffset, out uint status);
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.robabufs.ctrs}
+
+Since their contents are viewed as raw bytes, ByteAddressBuffers are defined as a simple variable definition.
+\begin{HLSL}
+  ByteAddressBuffer buf;
+\end{HLSL}
+
+When defined at global scope, ByteAccessBuffers are bound to externally-defined backing stores
+using the explicit binding location if provided or the implicit binding if not.
+
+When defined at local scope, ByteAccessBuffers represent local references
+that can be associated with global ByteAccessBuffers when assigned,
+but must be resolvable to a unique global buffer.
+
+\begin{HLSL}
+  ByteAddressBuffer gbuf;
+  void doit(bool b) {
+    ByteAddressBuffer lbuf = gbuf;
+  }
+\end{HLSL}
+
+\Sub{Dimensions}{Resources.robabufs.dims}
+
+The size of a ByteAddressBuffer can be retrieved using the \texttt{GetDimensions} method.
+\begin{HLSL}
+void GetDimensions(out uint size);
+\end{HLSL}
+
+This returns the full size of the buffer in bytes through the \texttt{width} out parameter.
+
+\Sub{Element Access}{Resources.robabufs.access}
+
+The contents of ByteAddressBuffers can be retrieved using the \texttt{Load} methods.
+
+\begin{HLSL}
+ uint Load(in uint byteOffset)
+ uint2 Load2(in uint byteOffset)
+ uint3 Load3(in uint byteOffset)
+ uint4 Load4(in uint byteOffset)
+\end{HLSL}
+
+These each return the bytes at the given position \texttt{byteOffset} in the form of one or more unsigned integers.
+The \texttt{byteOffset} address is in bytes and must be a multiple of 4.
+Each of the variants returns a number of bytes corresponding to the size of the uint vector returned.
+
+An additional templated load method allows returning the bytes at the given byte offset in the form
+of the type given in the template parameter. This can be a scalar, vector, matrix, or user-defined struct.
+
+\begin{HLSL}
+  template<typename T>
+  T Load(in uint byteOffset);
+\end{HLSL}
+
+The alignment requirements of \texttt{byteOffset} for this operation is the size in bytes of the largest
+scalar type contained in the given tyep \texttt{T}.
+
+Additional \texttt{Load} methods return the same values as the others,
+but also take a second \texttt{status} parameter that returns information about the accessed resource.
+\begin{HLSL}
+  uint Load(in uint byteOffset, out uint status)
+  uint2 Load2(in uint byteOffset, out uint status)
+  uint3 Load3(in uint byteOffset, out uint status)
+  uint4 Load4(in uint byteOffset, out uint status)
+  template<typename T>
+  T Load(in uint byteOffset, out uint status);
+\end{HLSL}
+
+The \texttt{status} parameter returns an indication of whether the value retrieved accessed a mapped tile
+resource on tile-based platforms. This parameter is interpretted using the \texttt{CheckAccessFullyMapped}
+built-in function. If tiled resources are enabled, it returns true if the value was accessed from a mapped
+tile resource and false otherwise. If tiled resourced are not enabled, it will return true.
+
+\Sec{Writable Byte Access Buffers}{Resources.rwbabufs}
+
+\begin{HLSL}
+ class RWByteAddressBuffer {
+
+   RWByteAddressBuffer();
+   RWByteAddressBuffer operator=(RWByteAddressBuffer buf);
+
+   void GetDimensions(out uint size);
+
+   // element access
+   uint Load(in uint byteOffset)
+   uint2 Load2(in uint byteOffset)
+   uint3 Load3(in uint byteOffset)
+   uint4 Load4(in uint byteOffset)
+   template<typename T>
+   T Load(in uint byteOffset);
+
+   uint Load(in uint byteOffset, out uint status)
+   uint2 Load2(in uint byteOffset, out uint status)
+   uint3 Load3(in uint byteOffset, out uint status)
+   uint4 Load4(in uint byteOffset, out uint status)
+   template<typename T>
+   T Load(in uint byteOffset, out uint status);
+
+   void Store(in uint byteOffset, in uint value)
+   void Store2(in uint byteOffset, in uint2 value)
+   void Store3(in uint byteOffset, in uint3 value)
+   void Store4(in uint byteOffset, in uint4 value)
+
+   template<typename T>
+   void Store(in uint byteOffset, in T value)
+
+   // 32-bit integer atomic arithmetic/bitwise operations
+   void InterlockedAdd(in uint pos, in uint value);
+   void InterlockedAdd(in uint pos, in uint value, out uint original)
+   void InterlockedAnd(in uint pos, in uint value);
+   void InterlockedAnd(in uint pos, in uint value, out uint original)
+   void InterlockedOr(in uint pos, in uint value);
+   void InterlockedOr(in uint pos, in uint value, out uint original)
+   void InterlockedXor(in uint pos, in uint value);
+   void InterlockedXor(in uint pos, in uint value, out uint original)
+
+   // 32-bit integer atomic comparison operations
+   void InterlockedMin(in uint pos, in int value)
+   void InterlockedMin(in uint pos, in uint value)
+   void InterlockedMin(in uint pos, in int value, out int original)
+   void InterlockedMin(in uint pos, in uint value, out uint original)
+   void InterlockedMax(in uint pos, in int value)
+   void InterlockedMax(in uint pos, in uint value)
+   void InterlockedMax(in uint pos, in int value, out int original)
+   void InterlockedMax(in uint pos, in uint value, out uint original)
+
+   // 32-bit integer atomic compare/exchange operations
+   void InterlockedCompareStore(in uint pos, in uint compare, in uint value);
+   void InterlockedExchange(in uint pos, in uint value, out uint original);
+   void InterlockedCompareExchange(in uint pos, in uint compare, in uint value,
+                                    out uint original);
+
+   // 64-bit integer atomic arithmatic/bitwise operations
+   void InterlockedAdd64(in uint pos, in uint64_t value);
+   void InterlockedAdd64(in uint pos, in uint64_t value, out uint64_t original)
+   void InterlockedAnd64(in uint pos, in uint64_t value);
+   void InterlockedAnd64(in uint pos, in uint64_t value, out uint64_t original)
+   void InterlockedOr64(in uint pos, in uint64_t value);
+   void InterlockedOr64(in uint pos, in uint64_t value, out uint64_t original)
+   void InterlockedXor64(in uint pos, in uint64_t value);
+   void InterlockedXor64(in uint pos, in uint64_t value, out uint64_t original)
+
+   // 64-bit integer atomic comparison operations
+   void InterlockedMin64(in uint pos, in int64_t value)
+   void InterlockedMin64(in uint pos, in int64_t value, out int64_t original)
+   void InterlockedMin64(in uint pos, in uint64_t value)
+   void InterlockedMin64(in uint pos, in uint64_t value, out uint64_t original)
+   void InterlockedMax64(in uint pos, in int64_t value)
+   void InterlockedMax64(in uint pos, in int64_t value, out int64_t original)
+   void InterlockedMax64(in uint pos, in uint64_t value)
+   void InterlockedMax64(in uint pos, in uint64_t value, out uint64_t original)
+
+   // 64-bit integer atomic compare/exchange operations
+   void InterlockedCompareStore64(in uint pos, in uint64_t compare, in uint64_t value);
+   void InterlockedExchange64(in uint pos, in int64_t value, out int64_t original);
+   void InterlockedCompareExchange64(in uint pos, in uint64_t compare,
+                                      in uint64_t value, out int64_t original);
+
+   // 32-bit float atomic compare/exchange operations
+   void InterlockedCompareStoreFloatBitwise(in uint byteOffest,
+                                             in float compare, in float value);
+   void InterlockedExchangeFloat(in uint byteOffest, in float value,
+                                  out float original);
+   void InterlockedCompareExchangeFloatBitwise(in uint byteOffest,
+                                                in float compare,
+                                                in float value,
+                                                out float original);
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.rwbabufs.ctrs}
+
+Since their contents are viewed as raw bytes, RWByteAddressBuffers are defined as a simple variable definition.
+\begin{HLSL}
+  RWByteAddressBuffer buf;
+\end{HLSL}
+
+When defined at global scope, RWByteAccessBuffers are bound to externally-defined backing stores
+using the explicit binding location if provided or the implicit binding if not.
+
+When defined at local scope, RWByteAccessBuffers represent local references
+that can be associated with global RWByteAccessBuffers when assigned,
+but must be resolvable to a unique global buffer.
+
+\begin{HLSL}
+  RWByteAddressBuffer gbuf;
+  void doit(bool b) {
+    RWByteAddressBuffer lbuf = gbuf;
+  }
+\end{HLSL}
+
+\Sub{Dimensions}{Resources.rwbabufs.dims}
+
+The size of a RWByteAddressBuffer can be retrieved using the \texttt{GetDimensions} method.
+\begin{HLSL}
+void GetDimensions(out uint size);
+\end{HLSL}
+
+This returns the full size of the buffer in bytes through the \texttt{width} out parameter.
+
+\Sub{Element Access}{Resources.rwbabufs.access}
+
+The contents of RWByteAccessBuffers can be retrieved using the \texttt{Load} methods.
+
+\begin{HLSL}
+ uint Load(in uint byteOffset)
+ uint2 Load2(in uint byteOffset)
+ uint3 Load3(in uint byteOffset)
+ uint4 Load4(in uint byteOffset)
+\end{HLSL}
+
+These each return the bytes at the given position \texttt{byteOffset} in the form of one or more unsigned integers.
+The \texttt{byteOffset} address is in bytes and must be a multiple of 4.
+Each of the variants returns a number of bytes corresponding to the size of the uint vector returned.
+
+An additional templated load method allows returning the bytes at the given byte offset in the form
+of the type given in the template parameter. This can be a scalar, vector, matrix, or user-defined struct.
+
+\begin{HLSL}
+  template<typename T>
+  T Load(in uint byteOffset);
+\end{HLSL}
+
+The alignment requirements of \texttt{byteOffset} for this operation is the size in bytes of the largest
+scalar type contained in the given tyep \texttt{T}.
+
+Additional \texttt{Load} methods return the same values as the others,
+but also take a second \texttt{status} parameter that returns information about the accessed resource.
+\begin{HLSL}
+  uint Load(in uint byteOffset, out uint status)
+  uint2 Load2(in uint byteOffset, out uint status)
+  uint3 Load3(in uint byteOffset, out uint status)
+  uint4 Load4(in uint byteOffset, out uint status)
+  template<typename T>
+  T Load(in uint byteOffset, out uint status);
+\end{HLSL}
+
+The \texttt{status} parameter returns an indication of whether the value retrieved accessed a mapped tile
+resource on tile-based platforms. This parameter is interpretted using the \texttt{CheckAccessFullyMapped}
+built-in function. If tiled resources are enabled, it returns true if the value was accessed from a mapped
+tile resource and false otherwise. If tiled resourced are not enabled, it will return true.
+
+
+\Sub{Atomic Operations}{Resources.rwbabufs.atomics}
+
+RWByteAddressBuffers have a suite of atomic methods that perform the given operation
+on signed or unsigned integer element data indexed by the given integer size
+in a way that ensures no contention from other threads performing other operations.
+Each has an overload that optionally returns the original value before the atomic operation was performed.
+
+\begin{HLSL}
+   void InterlockedAdd(in uint pos, in uint value);
+   void InterlockedAdd(in uint pos, in uint value, out uint original)
+   void InterlockedAnd(in uint pos, in uint value);
+   void InterlockedAnd(in uint pos, in uint value, out uint original)
+   void InterlockedOr(in uint pos, in uint value);
+   void InterlockedOr(in uint pos, in uint value, out uint original)
+   void InterlockedXor(in uint pos, in uint value);
+   void InterlockedXor(in uint pos, in uint value, out uint original)
+\end{HLSL}
+
+Performs atomic addition, bitwise and, bitwise or, or bitwise exclusive or
+on the element found in 32-bit integer position \texttt{pos} and the provided \texttt{value}
+and stores the resulting sum in that buffer position,
+optionally returning the orignal value of the buffer position through \texttt{original}
+
+\begin{HLSL}
+   void InterlockedMin(in uint pos, in int value)
+   void InterlockedMin(in uint pos, in uint value)
+   void InterlockedMin(in uint pos, in int value, out int original)
+   void InterlockedMin(in uint pos, in uint value, out uint original)
+   void InterlockedMax(in uint pos, in int value)
+   void InterlockedMax(in uint pos, in uint value)
+   void InterlockedMax(in uint pos, in int value, out int original)
+   void InterlockedMax(in uint pos, in uint value, out uint original)
+\end{HLSL}
+
+Performs the sign-approrpriate minimum or maximum comparison of the 32-bit integer indexed by \texttt{pos}
+and the provided \texttt{value} and assigns the less or greater as appropriate to that buffer position,
+optionally returning the orignal value at that buffer position through \texttt{original}
+
+\begin{HLSL}
+   void InterlockedExchange(in uint pos, in uint value, out uint original);
+\end{HLSL}
+
+Performs an atomic exchange of the the 32-bit integer indexed by \texttt{pos} with
+the value of \texttt{value} and returns the original value at that position through \texttt{original}.
+
+\begin{HLSL}
+   void InterlockedCompareStore(in uint pos, in uint compare, in uint value);
+   void InterlockedCompareExchange(in uint pos, in uint compare, in uint value,
+                                    out uint original);
+\end{HLSL}
+
+These perform an atomic exchange of or store to the the 32-bit integer indexed by \texttt{pos}
+with the provided \texttt{value} if the value at that position matches the value of \texttt{compare}.
+\texttt{InterlockedCompareExchange} returns the original value at that position through \texttt{original}.
+
+\begin{HLSL}
+   void InterlockedAdd64(in uint pos, in uint64_t value);
+   void InterlockedAdd64(in uint pos, in uint64_t value, out uint64_t original)
+   void InterlockedAnd64(in uint pos, in uint64_t value);
+   void InterlockedAnd64(in uint pos, in uint64_t value, out uint64_t original)
+   void InterlockedOr64(in uint pos, in uint64_t value);
+   void InterlockedOr64(in uint pos, in uint64_t value, out uint64_t original)
+   void InterlockedXor64(in uint pos, in uint64_t value);
+   void InterlockedXor64(in uint pos, in uint64_t value, out uint64_t original)
+\end{HLSL}
+
+Performs atomic addition, bitwise and, bitwise or, or bitwise exclusive or
+on the element found in 64-bit integer position \texttt{pos} and the provided \texttt{value}
+and stores the resulting sum in that buffer position,
+optionally returning the orignal value of the buffer position through \texttt{original}
+
+\begin{HLSL}
+   void InterlockedMin64(in uint pos, in int64_t value)
+   void InterlockedMin64(in uint pos, in uint64_t value)
+   void InterlockedMin64(in uint pos, in int64_t value, out int64_t original)
+   void InterlockedMin64(in uint pos, in uint64_t value, out uint64_t original)
+   void InterlockedMax64(in uint pos, in int64_t value)
+   void InterlockedMax64(in uint pos, in uint64_t value)
+   void InterlockedMax64(in uint pos, in int64_t value, out int64_t original)
+   void InterlockedMax64(in uint pos, in uint64_t value, out uint64_t original)
+\end{HLSL}
+
+Performs the sign-approrpriate minimum or maximum comparison of the 64-bit integer indexed by \texttt{pos}
+and the provided \texttt{value} and assigns the less or greater as appropriate to that buffer position,
+optionally returning the orignal value at that buffer position through \texttt{original}
+
+\begin{HLSL}
+   void InterlockedExchange64(in uint pos, in uint64_t value, out uint64_t original);
+\end{HLSL}
+
+Performs an atomic exchange of the the 64-bit integer indexed by \texttt{pos} with
+the value of \texttt{value} and returns the original value at that position through \texttt{original}.
+
+\begin{HLSL}
+   void InterlockedCompareStore64(in uint pos, in uint64_t compare,
+                                   in uint64_t value);
+   void InterlockedCompareExchange64(in uint pos, in uint64_t compare,
+                                      in uint64_t value, out uint64_t original);
+\end{HLSL}
+
+These perform an atomic exchange of or store to the the 64-bit integer indexed by \texttt{pos}
+with the provided \texttt{value} if the value at that position matches the value of \texttt{compare}.
+\texttt{InterlockedCompareExchange64} returns the original value at that position through \texttt{original}.
+
+\begin{HLSL}
+   void InterlockedExchangeFloat(in uint byteOffest, in float value,
+                                  out float original);
+\end{HLSL}
+
+Performs an atomic exchange of the the 32-bit float indexed by \texttt{pos} with
+the value of \texttt{value} and returns the original value at that position through \texttt{original}.
+
+\begin{HLSL}
+  void InterlockedCompareStoreFloatBitwise(in uint byteOffest, in float compare,
+                                            in float value);
+  void InterlockedCompareExchangeFloatBitwise(in uint byteOffest,
+                                               in float compare,
+                                               in float value,
+                                               out float original);
+\end{HLSL}
+
+These perform an atomic exchange of or store to the the 32-bit float indexed by \texttt{pos}
+with the provided \texttt{value} if the value at that position matches the value of \texttt{compare}
+in a bitwise comparison.
+Unlike standard floating point comparisons, values will only match if the bit representation matches
+which can miss some matching values that have different bit repesantations in addition to ignoring
+floating point rules surrounding NaN and infinite values.
+\texttt{InterlockedCompareExchangeFloatBitwise} returns the original value at that position through \texttt{original}.
+
+\Sec{Structured Buffers}{Resources.stbufs}
+
+StructuredBuffers are raw buffers with associated types that facilitate indexing.
+Unlike typed buffers, they perform no format conversions.
+The buffer contents is treated as raw data and the casting to the given types is done bit for bit.
+StructuredBuffers can be defined with scalar, vector, matrix, or user-defined struct elements.
+
+\Sec{Read-only Structured Buffers}{Resources.rostbufs}
+
+\begin{HLSL}
+template <typename T>
+ class StructuredBuffer {
+   StructuredBuffer();
+   StructuredBuffer operator=(StructuredBuffer buf);
+
+   void GetDimensions(out uint count, out uint stride);
+
+   // element access
+   T operator[](uint pos);
+   T Load(in int pos);
+   T Load(in int pos, out uint status);
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.rostbufs.ctrs}
+
+StructuredBuffers must be defined with explicit template parameter types.
+\begin{HLSL}
+  struct S {int i; float f;};
+  StructuredBuffer<S> buf1;
+  StructuredBuffer<float4> buf2;
+  StructuredBuffer<float2x3> buf3;
+\end{HLSL}
+
+When defined at global scope, StructuredBuffers are bound to externally-defined backing stores
+using the explicit binding location if provided or the implicit binding if not.
+
+When defined at local scope, StructuredBuffers represent local references
+that can be associated with global buffers when assigned,
+but must be resolvable to a unique global buffer.
+
+\begin{HLSL}
+  StructuredBuffer<int3x3> gbuf;
+  void doit() {
+    StructuredBuffer lbuf<int3x3> = gbuf;
+  }
+\end{HLSL}
+StructuredBuffer operands to the assignment operator must have the same element type.
+
+\Sub{Dimensions}{Resources.rostbufs.dims}
+
+The structure count and stride of a StructuredBuffer can be retrieved using the \texttt{GetDimensions} method.
+\begin{HLSL}
+void GetDimensions(out uint count, out uint stride);
+\end{HLSL}
+
+This returns number of structured elements of the buffer through the \texttt{count} out parameter
+and the size of each element in bytes through the \texttt{stride} out parameter.
+
+\Sub{Element Access}{Resources.rostbufs.access}
+
+The contents of StructuredBuffers can be retrieved using the \texttt{Load} methods
+or the subscript operator.
+
+\begin{HLSL}
+ T Load(in int pos);
+ T operator[](uint pos);
+\end{HLSL}
+
+These each return the element at the given position \texttt{pos} of the type specified in the buffer definition.
+
+An additional \texttt{Load} method returns the indicated element just as the other,
+but also takes a second \texttt{status} parameter that returns information about the accessed resource.
+\begin{HLSL}
+ T Load(in int pos, out uint status);
+\end{HLSL}
+
+The \texttt{status} parameter returns an indication of whether the value retrieved accessed a mapped tile
+resource on tile-based platforms. This parameter is interpretted using the \texttt{CheckAccessFullyMapped}
+built-in function. If tiled resources are enabled, it returns true if the value was accessed from a mapped
+tile resource and false otherwise. If tiled resourced are not enabled, it will return true.
+
+\Sec{Writable Structured Buffers}{Resources.rwstbufs}
+
+\begin{HLSL}
+template <typename T>
+ class RWStructuredBuffer {
+   RWStructuredBuffer();
+   RWStructuredBuffer operator=(RWStructuredBuffer buf);
+
+   void GetDimensions(out uint count, out uint stride);
+
+   // element access
+   T operator[](uint pos);
+   T Load(in int pos);
+   T Load(in int pos, out uint status);
+
+   // Hidden counter increment/decrement
+   uint IncrementCounter();
+   uint DecrementCounter();
+
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.rwstbufs.ctrs}
+
+RWStructuredBuffers must be defined with explicit template parameter types.
+\begin{HLSL}
+  struct S {int i; float f;};
+  RWStructuredBuffer<S> buf1;
+  RWStructuredBuffer<float4> buf2;
+  RWStructuredBuffer<float2x3> buf3;
+\end{HLSL}
+
+When defined at global scope, RWStructuredBuffers are bound to externally-defined backing stores
+using the explicit binding location if provided or the implicit binding if not.
+
+When defined at local scope, RWStructuredBuffers represent local references
+that can be associated with global buffers when assigned,
+but must be resolvable to a unique global buffer.
+
+\begin{HLSL}
+  RWStructuredBuffer<int3x3> gbuf;
+  void doit() {
+    RWStructuredBuffer lbuf<int3x3> = gbuf;
+  }
+\end{HLSL}
+RWStructuredBuffer operands to the assignment operator must have the same element type.
+
+\Sub{Dimensions}{Resources.rwstbufs.dims}
+
+The structure count and stride of a RWStructuredBuffer can be retrieved using the \texttt{GetDimensions} method.
+\begin{HLSL}
+void GetDimensions(out uint count, out uint stride);
+\end{HLSL}
+
+This returns number of structured elements of the buffer through the \texttt{count} out parameter
+and the size of each element in bytes through the \texttt{stride} out parameter.
+
+\Sub{Element Access}{Resources.rwstbufs.access}
+
+The contents of RWStructuredBuffers can be retrieved using the \texttt{Load} methods
+or the subscript operator.
+
+\begin{HLSL}
+ T Load(in int pos);
+ T operator[](uint pos);
+\end{HLSL}
+
+These each return the element at the given position \texttt{pos} of the type specified in the buffer definition.
+
+An additional \texttt{Load} method returns the indicated element just as the other,
+but also takes a second \texttt{status} parameter that returns information about the accessed resource.
+\begin{HLSL}
+ T Load(in int pos, out uint status);
+\end{HLSL}
+
+The \texttt{status} parameter returns an indication of whether the value retrieved accessed a mapped tile
+resource on tile-based platforms. This parameter is interpretted using the \texttt{CheckAccessFullyMapped}
+built-in function. If tiled resources are enabled, it returns true if the value was accessed from a mapped
+tile resource and false otherwise. If tiled resourced are not enabled, it will return true.
+
+\Sub{Counter Manipulation}{Resources.rwstbufs.counter}
+
+\begin{HLSL}
+   uint IncrementCounter();
+   uint DecrementCounter();
+\end{HLSL}
+
+Increments or decrements the hidden counter associated with the RWStructuredbuffer.
+
+\Sec{AppendStructuredBuffer}{Resources.apstbufs}
+
+AppendStructuredBuffers are buffers that can only be appended to as an output stream.
+
+\begin{HLSL}
+template <typename T>
+ class AppendStructuredBuffer {
+   AppendStructuredBuffer();
+   AppendStructuredBuffer operator=(AppendStructuredBuffer buf);
+
+   void GetDimensions(out uint count, out uint stride);
+
+   void Append(in T value);
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.apstbufs.ctrs}
+
+AppendStructuredBuffers must be defined with explicit template parameter types.
+\begin{HLSL}
+  struct S {int i; float f;};
+  AppendStructuredBuffer<S> buf1;
+  AppendStructuredBuffer<float4> buf2;
+  AppendStructuredBuffer<float2x3> buf3;
+\end{HLSL}
+
+When defined at global scope, AppendStructuredBuffers are bound to externally-defined backing stores
+using the explicit binding location if provided or the implicit binding if not.
+
+When defined at local scope, AppendStructuredBuffers represent local references
+that can be associated with global buffers when assigned,
+but must be resolvable to a unique global buffer.
+
+\begin{HLSL}
+  AppendStructuredBuffer<int3x3> gbuf;
+  void doit() {
+    AppendStructuredBuffer lbuf<int3x3> = gbuf;
+  }
+\end{HLSL}
+AppendStructuredBuffer operands to the assignment operator must have the same element type.
+
+\Sub{Dimensions}{Resources.apstbufs.dims}
+
+The structure count and stride of a AppendStructuredBuffer can be retrieved using the \texttt{GetDimensions} method.
+\begin{HLSL}
+void GetDimensions(out uint count, out uint stride);
+\end{HLSL}
+
+This returns number of structured elements of the buffer through the \texttt{count} out parameter
+and the size of each element in bytes through the \texttt{stride} out parameter.
+
+\Sub{Append}{Resources.apstbufs.append}
+
+\begin{HLSL}
+   void Append(in T value )
+\end{HLSL}
+
+Appends the \texttt{value} of the template parameter types to the end of the AppendStructuredBuffer.
+Subsequent appends will continue to add elements to the end of the buffer.
+
+\Sec{ConsumeStructuredBuffer}{Resources.cnstbufs}
+
+ConsumeStructuredBuffers are buffers that can only have values pulled from them as an input stream.
+
+\begin{HLSL}
+template <typename T>
+ class ConsumeStructuredBuffer {
+   ConsumeStructuredBuffer();
+   ConsumeStructuredBuffer operator=(ConsumeStructuredBuffer buf);
+
+   void GetDimensions(out uint count, out uint stride);
+
+   void Consume();
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.cnstbufs.ctrs}
+
+ConsumeStructuredBuffers must be defined with explicit template parameter types.
+\begin{HLSL}
+  struct S {int i; float f;};
+  ConsumeStructuredBuffer<S> buf1;
+  ConsumeStructuredBuffer<float4> buf2;
+  ConsumeStructuredBuffer<float2x3> buf3;
+\end{HLSL}
+
+When defined at global scope, ConsumeStructuredBuffers are bound to externally-defined backing stores
+using the explicit binding location if provided or the implicit binding if not.
+
+When defined at local scope, ConsumeStructuredBuffers represent local references
+that can be associated with global buffers when assigned,
+but must be resolvable to a unique global buffer.
+
+\begin{HLSL}
+  ConsumeStructuredBuffer<int3x3> gbuf;
+  void doit() {
+    ConsumeStructuredBuffer lbuf<int3x3> = gbuf;
+  }
+\end{HLSL}
+ConsumeStructuredBuffer operands to the assignment operator must have the same element type.
+
+\Sub{Dimensions}{Resources.cnstbufs.dims}
+
+The structure count and stride of a ConsumeStructuredBuffer can be retrieved using the \texttt{GetDimensions} method.
+\begin{HLSL}
+void GetDimensions(out uint count, out uint stride);
+\end{HLSL}
+
+This returns number of structured elements of the buffer through the \texttt{count} out parameter
+and the size of each element in bytes through the \texttt{stride} out parameter.
+
+\Sub{Consume}{Resources.cnstbufs.consume}
+
+\begin{HLSL}
+   void Consume();
+\end{HLSL}
+
+Removes and returns a value of the template parameter types from the end of the ConsumeStructuredBuffer.
+
+\Sec{Constant Buffers}{Resources.cnbuf}
+
+\Sec{Samplers}{Resources.samp}
+
+
+\Sec{Resource Binding}{Resources.binding}
+
+Resources are bound to external memory using virtual registers within logical registers spaces.
+These can be specified explicitly using attributes after the global resource declaration
+or implicitly by leaving them off.
+
+\begin{grammar}
+  \define{resource-binding}\br
+  \terminal{: register(} register-type bind-number \terminal{)}\br
+  \terminal{: register(} register-type bind-number , \terminal{space} bind-number \terminal{)}\br
+
+  \define{register-type} \textnormal{one of}\br
+  \terminal{t u b s}\br
+
+  \define{bind-number}\br
+  digit\br
+  bind-number digit\br
+\end{grammar}
+
+The register type indicates whether the binding is for a read-only SRV (\texttt{t}), a writable UAV (\texttt{u}),
+a constant buffer (\texttt{b}), or a sampler (\texttt{s}).
+The register bind number indicates the register number at which the resource variable begins.
+The optional second parameter indicates the virtual register space that the register belongs to.
+
+Sample syntax of virtual register binding attributes:
+\begin{HLSL}
+  Buffer<float> robuf : register(t0, space0);
+  RWBuffer<float> rwbuf : register(u0, space0);
+  SamplerState samp : register(s0, space0);
+  cbuffer cbuf : register(b0, space0) { float f; };
+\end{HLSL}
+
+Each resource must have a unique register. Different resources cannot occupy the same register,
+but SRVs and UAVs have separate namespaces and different logical register spaces have independent
+sets of register numbers. Meaning the following is all allowed:
+\begin{HLSL}
+  Buffer<float> mybuf : register(t0, space0);
+  Buffer<float> yourbuf : register(t0, space1);
+  RWBuffer<float> hisbuf : register(u0, space0);
+  RWBuffer<float> herbuf : register(u0, space1);
+\end{HLSL}
+
+Resource arrays occupy the first register they specify as well as however many additional registers
+the array requires to assign a register to each of its elements.
+
+\begin{HLSL}
+  Buffer<float> fbuf[3] : register(t0, space0); // occupies t0, t1, and t2
+  Buffer<int4> ibuf[4][3] : register(t3, space0); // occupies registers t3 - t15
+\end{HLSL}
+
+If the register binding or register space is not specified, implicit values are used.
+Whenever not specified, the space defaults to \texttt{space0}.
+
+\begin{HLSL}
+  Buffer<float2> buf1 : register(t0, space0);
+  Buffer<float2> buf2 : register(t1); // defaults to space0
+\end{HLSL}
+
+When the register is not specified, resources will recieve implementation-dependent register assignments.


### PR DESCRIPTION
This adds a resource chapter that documents typed and raw buffers including their methods and compatible operators along with short descriptions of their functionality. It also adds a description of binding annotations for all types. Stub sections are included for constant buffers and samplers, but no information is provided as yet.

Fixes https://github.com/llvm/wg-hlsl/issues/55
Fixes https://github.com/llvm/wg-hlsl/issues/56