### PR TITLE
Design Meeting Minutes - 2025/01/21

### DIFF
--- a/docs/DesignMeetingMinutes/2025-01-21.md
+++ b/docs/DesignMeetingMinutes/2025-01-21.md
@@ -1,0 +1,11 @@
+# Design Meeting Minutes: 2025/01/21
+
+> NOTE: Please read the [terms of participation](DesignMeetingTerms.txt)
+> ("Terms") prior to joining the Teams meeting.  You joining the Teams meeting
+> with Microsoft indicates your acknowledgement, agreement, and consent to these
+> Terms.  If you do not agree to these Terms, please do not join the meeting.
+>
+> If you intend to contribute code or other copyrightable materials (e.g.
+> written comments, tools, documentation, etc.)  to the hlsl specs repository,
+> you are required to sign a Contributor License Agreement (CLA).  For details,
+> visit https://cla.microsoft.com.

--- a/docs/DesignMeetingMinutes/2025-01-21.md
+++ b/docs/DesignMeetingMinutes/2025-01-21.md
@@ -9,3 +9,48 @@
 > written comments, tools, documentation, etc.)  to the hlsl specs repository,
 > you are required to sign a Contributor License Agreement (CLA).  For details,
 > visit https://cla.microsoft.com.
+
+* Administrivia
+  * Meeting timing & cadence
+    * Current meeting is scheduled every other week on Tuesday at 5pm GMT, 12pm ET, 9am PT
+    * Once attendence stabilizes in a month or so we'll revisit the meeting cadence and timing
+  * Release Overview
+    * Upcoming HLSL language versions are 202x (DXC & Clang) and 202y (Clang-only)
+    * Upcoming Shader Model versions are 6.9 (DXIL - DXC & Clang) and 7.0 (SPIR-V - Clang-only)
+* Issues
+  * https://github.com/microsoft/hlsl-specs/issues/360
+    * Action Item: @tex3d and @llvm-beanz to coordinate with @bob80905 to ensure the spec gets updated.
+* PRs
+  * https://github.com/microsoft/hlsl-specs/pull/13
+    * Closed due to no driving engineer. This was not a user-requested feature and we believe it may encourage users to use ByteAddressBuffer in ways that are not performant. We should revisit how resource types work with references as part of the references proposal.
+  * https://github.com/microsoft/hlsl-specs/pull/34
+    * Action Item: @llvm-beanz will review to ensure it is reflective of changes since the PR was first posted.
+    * Action Item: @tex3d and @pow2clk to review the PR and comment
+  * https://github.com/microsoft/hlsl-specs/pull/61
+    * We are committed to bringing a wave matrix feature to HLSL with the target being SM 6.9. It will substantially deviate from the proposal in this PR, so it probably isn't useful to use this PR as a base.
+    * Action Item: @llvm-beanz to close.
+  * https://github.com/microsoft/hlsl-specs/pull/65
+    * Action Item: @pow2clk to review.
+  * https://github.com/microsoft/hlsl-specs/pull/77
+    * This isn't really in a great shape, but it is useful documentation to not lose.
+    * Action Item: @llvm-beanz to merge
+  * https://github.com/microsoft/hlsl-specs/pull/154
+    * The general consensus is that this may be part of a larger set of features we need in HLSL for managing alignment of data more explicitly. 
+    * Filed issue to track: https://github.com/microsoft/hlsl-specs/issues/369
+  * * https://github.com/microsoft/hlsl-specs/pull/200
+    * Action Item: @damyanp to close since this should be tracked in https://github.com/llvm/wg-hlsl
+  * https://github.com/microsoft/hlsl-specs/pull/277
+    * This is a major feature for SM 6.9.
+    * Assigned to @derlemsft who is helping usher the feature.
+    * Next steps: (1) File issues to track outstanding problems, (2) merge proposal, (3) rinse and repeat
+  * https://github.com/microsoft/hlsl-specs/pull/317
+    * AMD will have updates in a week or two on this
+    * Action Item: Will re-review at the next meeting.
+  * https://github.com/microsoft/hlsl-specs/pull/324
+    * @damyanp and @llvm-beanz are uncertain that the appraoch of adding a "non-semantic" instruction for printf in DXIL is the right design appraoch.
+    * This feature will also require design coordination with the Direct3D and PIX teams.
+    * @pow2clk and @tex3d will review this in more detail.
+    * Action Item: Schedule a deep-dive on this feature in a future design meeting.
+  * https://github.com/microsoft/hlsl-specs/pull/361
+    * @pow2clk is aiming to merge this later this week. Seems to be on track.
+    * Action Item: @llvm-beanz to review.

--- a/docs/DesignMeetingMinutes/2025-01-21.md
+++ b/docs/DesignMeetingMinutes/2025-01-21.md
@@ -10,47 +10,50 @@
 > you are required to sign a Contributor License Agreement (CLA).  For details,
 > visit https://cla.microsoft.com.
 
-* Administrivia
+## Administrivia
   * Meeting timing & cadence
     * Current meeting is scheduled every other week on Tuesday at 5pm GMT, 12pm ET, 9am PT
     * Once attendence stabilizes in a month or so we'll revisit the meeting cadence and timing
   * Release Overview
     * Upcoming HLSL language versions are 202x (DXC & Clang) and 202y (Clang-only)
     * Upcoming Shader Model versions are 6.9 (DXIL - DXC & Clang) and 7.0 (SPIR-V - Clang-only)
-* Issues
-  * https://github.com/microsoft/hlsl-specs/issues/360
-    * Action Item: @tex3d and @llvm-beanz to coordinate with @bob80905 to ensure the spec gets updated.
-* PRs
-  * https://github.com/microsoft/hlsl-specs/pull/13
-    * Closed due to no driving engineer. This was not a user-requested feature and we believe it may encourage users to use ByteAddressBuffer in ways that are not performant. We should revisit how resource types work with references as part of the references proposal.
-  * https://github.com/microsoft/hlsl-specs/pull/34
-    * Action Item: @llvm-beanz will review to ensure it is reflective of changes since the PR was first posted.
-    * Action Item: @tex3d and @pow2clk to review the PR and comment
-  * https://github.com/microsoft/hlsl-specs/pull/61
-    * We are committed to bringing a wave matrix feature to HLSL with the target being SM 6.9. It will substantially deviate from the proposal in this PR, so it probably isn't useful to use this PR as a base.
-    * Action Item: @llvm-beanz to close.
-  * https://github.com/microsoft/hlsl-specs/pull/65
-    * Action Item: @pow2clk to review.
-  * https://github.com/microsoft/hlsl-specs/pull/77
-    * This isn't really in a great shape, but it is useful documentation to not lose.
-    * Action Item: @llvm-beanz to merge
-  * https://github.com/microsoft/hlsl-specs/pull/154
-    * The general consensus is that this may be part of a larger set of features we need in HLSL for managing alignment of data more explicitly. 
-    * Filed issue to track: https://github.com/microsoft/hlsl-specs/issues/369
-  * * https://github.com/microsoft/hlsl-specs/pull/200
-    * Action Item: @damyanp to close since this should be tracked in https://github.com/llvm/wg-hlsl
-  * https://github.com/microsoft/hlsl-specs/pull/277
-    * This is a major feature for SM 6.9.
-    * Assigned to @derlemsft who is helping usher the feature.
-    * Next steps: (1) File issues to track outstanding problems, (2) merge proposal, (3) rinse and repeat
-  * https://github.com/microsoft/hlsl-specs/pull/317
-    * AMD will have updates in a week or two on this
-    * Action Item: Will re-review at the next meeting.
-  * https://github.com/microsoft/hlsl-specs/pull/324
-    * @damyanp and @llvm-beanz are uncertain that the appraoch of adding a "non-semantic" instruction for printf in DXIL is the right design appraoch.
-    * This feature will also require design coordination with the Direct3D and PIX teams.
-    * @pow2clk and @tex3d will review this in more detail.
-    * Action Item: Schedule a deep-dive on this feature in a future design meeting.
-  * https://github.com/microsoft/hlsl-specs/pull/361
-    * @pow2clk is aiming to merge this later this week. Seems to be on track.
-    * Action Item: @llvm-beanz to review.
+## Issues
+
+* https://github.com/microsoft/hlsl-specs/issues/360
+  * Action Item: @tex3d and @llvm-beanz to coordinate with @bob80905 to ensure the spec gets updated.
+
+## PRs
+
+* https://github.com/microsoft/hlsl-specs/pull/13
+  * Closed due to no driving engineer. This was not a user-requested feature and we believe it may encourage users to use ByteAddressBuffer in ways that are not performant. We should revisit how resource types work with references as part of the references proposal.
+* https://github.com/microsoft/hlsl-specs/pull/34
+  * Action Item: @llvm-beanz will review to ensure it is reflective of changes since the PR was first posted.
+  * Action Item: @tex3d and @pow2clk to review the PR and comment
+* https://github.com/microsoft/hlsl-specs/pull/61
+  * We are committed to bringing a wave matrix feature to HLSL with the target being SM 6.9. It will substantially deviate from the proposal in this PR, so it probably isn't useful to use this PR as a base.
+  * Action Item: @llvm-beanz to close.
+* https://github.com/microsoft/hlsl-specs/pull/65
+  * Action Item: @pow2clk to review.
+* https://github.com/microsoft/hlsl-specs/pull/77
+  * This isn't really in a great shape, but it is useful documentation to not lose.
+  * Action Item: @llvm-beanz to merge
+* https://github.com/microsoft/hlsl-specs/pull/154
+  * The general consensus is that this may be part of a larger set of features we need in HLSL for managing alignment of data more explicitly. 
+  * Filed issue to track: https://github.com/microsoft/hlsl-specs/issues/369
+* https://github.com/microsoft/hlsl-specs/pull/200
+  * Action Item: @damyanp to close since this should be tracked in https://github.com/llvm/wg-hlsl
+* https://github.com/microsoft/hlsl-specs/pull/277
+  * This is a major feature for SM 6.9.
+  * Assigned to @derlemsft who is helping usher the feature.
+  * Next steps: (1) File issues to track outstanding problems, (2) merge proposal, (3) rinse and repeat
+* https://github.com/microsoft/hlsl-specs/pull/317
+  * AMD will have updates in a week or two on this
+  * Action Item: Will re-review at the next meeting.
+* https://github.com/microsoft/hlsl-specs/pull/324
+  * @damyanp and @llvm-beanz are uncertain that the appraoch of adding a "non-semantic" instruction for printf in DXIL is the right design appraoch.
+  * This feature will also require design coordination with the Direct3D and PIX teams.
+  * @pow2clk and @tex3d will review this in more detail.
+  * Action Item: Schedule a deep-dive on this feature in a future design meeting.
+* https://github.com/microsoft/hlsl-specs/pull/361
+  * @pow2clk is aiming to merge this later this week. Seems to be on track.
+  * Action Item: @llvm-beanz to review.


### PR DESCRIPTION
This PR adds the meeting minutes for the design meeting on 2025/01/21.