### PR TITLE
Update INF-0004-validator-hashing.md with applicable AgilitySDK version

### DIFF
--- a/proposals/infra/INF-0004-validator-hashing.md
+++ b/proposals/infra/INF-0004-validator-hashing.md
@@ -167,7 +167,7 @@ even less likely.
 
 ### D3D Runtime Behavior
 
-Starting with AgilitySDK version TBD, the runtime adopts new behavior for how 
+Starting with AgilitySDK version 1.615, the runtime adopts new behavior for how 
 and when the shader hash is validated, including support for bytecode validation 
 in the debug layer.
 


### PR DESCRIPTION
Now that we know which AgilitySDK version will support hash bypass, the "TBD" in the spec can be replaced with the actual version. 

Also consider whether to move this out of "proposal" state, perhaps as soon as that AgilitySDK becomes available?  Actually might need to stay in proposal state until any DXC side changes are finished, such as publishing dxil.dll?