### PR TITLE
[OMM] Remove validation masking, update spec

### DIFF
--- a/proposals/0024-opacity-micromaps.md
+++ b/proposals/0024-opacity-micromaps.md
@@ -203,10 +203,6 @@ Proposed warning diagnostic:
   This new warning will have a new warning group to allow it to be targeted
   easily for command-line override, such as `hlsl-availability-constant`.
 
-Current HLSL diagnostics in DXC do not verify `RayFlags` values in any context.
-`TraceRay()` and `RayQuery::TraceRayInline()` accept non-immediate values, but
-the `RayFlags` provided as a template argument to `RayQuery` must be immediate.
-
 A check will be added on the declaration of a RayQuery object 
 (when not dependent), so that when the RayQueryFlags template argument is
 non-zero, it requires shader model 6.9 or above.
@@ -344,7 +340,7 @@ See [Opacity Micromaps][dxr-omm] in the Raytracing spec for details.
   - Check both DXR entry scenarios and non-library RayQuery scenarios.
 - Check that any RayQuery object with the `RayFlag::ForceOMM2State` flag
   in its first template argument also has an accompanying 
-  `RAYQUERY_FLAG::RAYQUERY_FLAG_ALLOW_OPACITY_MICROMAPS` flag.
+  `RAYQUERY_FLAG_ALLOW_OPACITY_MICROMAPS` flag.
 - Check diagnostics for subobject, and lack of diagnostics for non-library
   target, where subobjects are ignored.
 - Test the custom HLSL availability attribute, that it correctly locates

--- a/proposals/0024-opacity-micromaps.md
+++ b/proposals/0024-opacity-micromaps.md
@@ -136,8 +136,8 @@ DXIL op is used.
 
 The new DXIL Op, `AllocateRayQuery2`, will have this signature:
 ```DXIL
-; Function Attrs:
-nounwind declare i32 @dx.op.allocateRayQuery2(i32 OpCode, i32 constRayFlags, i32 RayQueryFlags)
+; Function Attrs: nounwind 
+declare i32 @dx.op.allocateRayQuery2(i32 OpCode, i32 constRayFlags, i32 RayQueryFlags)
 ```
 
 The DXIL operations which either accept or return `RayFlags`, and therefore may
@@ -229,8 +229,8 @@ point to the RayQuery object declaration, where this RayQueryFlag needs to be
 specified.
 
 #### Validation Changes
-Three DXIL operations accept `RayFlags` as input, but only one requires this
-input to be immediate: `AllocateRayQuery`.
+Four DXIL operations accept `RayFlags` as input, but only two requires these
+flags input to be immediate: `AllocateRayQuery` and `AllocateRayQuery2`.
 
 Validation will be added to ensure the flags are constant on input to
 the `AllocateRayQuery` and `AllocateRayQuery2` DXIL operation.

--- a/proposals/0024-opacity-micromaps.md
+++ b/proposals/0024-opacity-micromaps.md
@@ -336,7 +336,7 @@ See [Opacity Micromaps][dxr-omm] in the Raytracing spec for details.
 ### Diagnostics
 
 - Check availability-based diagnostics for each flag, including recursing
-  through DeclRefs, DeclExprRefs, and their initializers.
+  through DeclRefExprs to Decls and their initializers.
   - Check both DXR entry scenarios and non-library RayQuery scenarios.
 - Check that any RayQuery object with the `RayFlag::ForceOMM2State` flag
   in its first template argument also has an accompanying 


### PR DESCRIPTION
No validation mask is needed for the new OMM flags. Source level validation is still needed to ensure the flags are used correctly, but the validator will not need to run the flags through a mask to validate them. Additionally, this PR removes any mention of flag value validation, except for one specific case where a RayQuery ray flag template argument necessitates the RayQuery ray query flag template argument's value. 
This PR updates the spec to reflect new changes to the validator, and proposes some new diagnostics with the new RAYQUERY_FLAG_ALLOW_OPACITY_MICROMAPS flag. It defines a new DXIL OP, `AllocateRayQuery2`, which will be generated when RayQuery is given a 2nd, optional, ray query template flag argument in HLSL. 

This PR is a transfer from https://github.com/microsoft/hlsl-specs/pull/374

Fixes https://github.com/microsoft/hlsl-specs/issues/375
Fixes https://github.com/microsoft/hlsl-specs/issues/360