### PR TITLE
[0027] Shader Execution Reordering: rename "ReorderThread" to "MaybeReorderThread"

### DIFF
--- a/proposals/0027-shader-execution-reordering.md
+++ b/proposals/0027-shader-execution-reordering.md
@@ -10,11 +10,11 @@ Michael Haidl, Simon Moll, Martin Stich
 
 ## Introduction
 
-This proposal introduces `TryReorderThread`, a built-in function for raygeneration shaders to
+This proposal introduces `MaybeReorderThread`, a built-in function for raygeneration shaders to
 explicitly specify where and how shader execution coherence can be improved.
 Additionally, `HitObject` is introduced to decouple traversal, intersection
 testing and anyhit shading from closesthit and miss shading. Decoupling these
-shader stages gives an increase in flexibility and enables `TryReorderThread` to
+shader stages gives an increase in flexibility and enables `MaybeReorderThread` to
 improve coherence for closesthit and miss shading, as well as subsequent operations.
 
 ## Motivation
@@ -41,13 +41,13 @@ the hit which must be transferred back to the caller through the payload.
 ## Proposed Solution
 
 Shader Execution Reordering (SER) introduces a new HLSL built-in intrinsic,
-`TryReorderThread`,
+`MaybeReorderThread`,
 that enables application-controlled reordering of work across the GPU for
 improved execution and data coherence.
 Additionally, the introduction of `HitObject` allows separation of traversal,
 anyhit shading and intersection testing from closesthit and miss shading.
 
-`HitObject` and `TryReorderThread` can be combined to improve coherence for
+`HitObject` and `MaybeReorderThread` can be combined to improve coherence for
 closesthit and miss shader execution in a controlled manner.
 Applications can control coherence based on hit properties,
 ray generation state, ray payload, or any combination thereof. Applications can
@@ -62,14 +62,14 @@ raygeneration shader and execute before closesthit shading. Second, simple
 visibility rays no longer have to invoke hit shaders in order to access basic
 information about the hit, such as the distance to the closest hit. Finally,
 `HitObject` can be constructed from a `RayQuery`, which enables
-`TryReorderThread` and shader table-based closesthit and miss shading to be combined with
+`MaybeReorderThread` and shader table-based closesthit and miss shading to be combined with
 `RayQuery`.
 
 The proposed extension to HLSL should be relatively straightforward to adopt by
 current DXR implementations: `HitObject` merely decouples existing `TraceRay`
 functionality into two distinct stages: the traversal stage and the shading
 stage.
-For SER's `TryReorderThread`, the minimal allowed implementation is simply a
+For SER's `MaybeReorderThread`, the minimal allowed implementation is simply a
 no-op, while implementations that already employ more sophisticated scheduling
 strategies are likely able to reuse existing mechanisms to implement support
 for SER. No DXR runtime changes are necessary, since the proposed extension to
@@ -77,25 +77,25 @@ the programming model is limited to HLSL and DXIL.
 
 ## Detailed Design
 
-This section describes the HLSL additions for `HitObject` and `TryReorderThread`
+This section describes the HLSL additions for `HitObject` and `MaybeReorderThread`
 in detail.
 The canonical use of these features involve changing a `TraceRay` call to the
 following sequence that is functionally equivalent:
 
 ```C++
 HitObject Hit = HitObject::TraceRay( ..., Payload );
-TryReorderThread( Hit );
+MaybeReorderThread( Hit );
 HitObject::Invoke( Hit, Payload );
 ```
 
 This snippet traces a ray and stores the result of traversal, intersection
-testing and anyhit shading in `Hit`. The call to `TryReorderThread` improves
+testing and anyhit shading in `Hit`. The call to `MaybeReorderThread` improves
 coherence based on the information inside the `Hit`. Closesthit or miss
 shading is then invoked in a more coherent context.
 
 Note that this is a very basic example. Among other things, it is possible to
-query information about the hit to influence `TryReorderThread` with additional
-hints. See [Separation of TryReorderThread and HitObject::Invoke](#separation-of-TryReorderThread-and-hitobjectinvoke)
+query information about the hit to influence `MaybeReorderThread` with additional
+hints. See [Separation of MaybeReorderThread and HitObject::Invoke](#separation-of-MaybeReorderThread-and-hitobjectinvoke)
 for more elaborate examples.
 
 ### HitObject HLSL Additions
@@ -108,7 +108,7 @@ The `HitObject` type encapsulates information about a hit or a miss. A
 `HitObject` is constructed using `HitObject::TraceRay`,
 `HitObject::FromRayQuery`, `HitObject::MakeMiss`, or `HitObject::MakeNop`. It
 can be used to invoke closesthit or miss shading using `HitObject::Invoke`,
-and to reorder threads for shading coherence with `TryReorderThread`.
+and to reorder threads for shading coherence with `MaybeReorderThread`.
 
 The `HitObject` has value semantics, so modifying one `HitObject` will not
 impact any other `HitObject` in the shader. A shader can have any number of
@@ -122,7 +122,7 @@ assignment (by-value copy) and can be passed as arguments to and returned from
 local inlined functions.
 
 A `HitObject` is default-initialized to encode a NOP-HitObject (see `HitObject::MakeNop`).
-A NOP-HitObject can be used with `HitObject::Invoke` and `TryReorderThread` but
+A NOP-HitObject can be used with `HitObject::Invoke` and `MaybeReorderThread` but
 does not call shaders or provide additional information for reordering.
 Most accessors will return zero-initialized values for a NOP-HitObject.
 
@@ -229,7 +229,7 @@ Parameter                           | Definition
 
 Construct a NOP-HitObject that represents neither a hit nor a miss. This is
 the same as a default-initialized `HitObject`. NOP-HitObjects can be useful in
-certain scenarios when combined with `TryReorderThread`, e.g., when a thread
+certain scenarios when combined with `MaybeReorderThread`, e.g., when a thread
 wants to participate in reordering without executing a closesthit or miss
 shader.
 
@@ -658,32 +658,32 @@ the following additional PAQ rules apply:
 - At the call to `HitObject::Invoke`, any field declared as `write(anyhit)`
 is treated as `write(caller)`
 
-### TryReorderThread HLSL Additions
+### MaybeReorderThread HLSL Additions
 
-`TryReorderThread` provides an efficient way for the application to reorder work
+`MaybeReorderThread` provides an efficient way for the application to reorder work
 across the physical threads running on the GPU in order to improve the
 coherence and performance of subsequently executed code. The target ordering
-is given by the arguments passed to `TryReorderThread`. For example, the
+is given by the arguments passed to `MaybeReorderThread`. For example, the
 application can pass a `HitObject`, indicating to the system that coherent
 execution is desired with respect to a ray hit location in the scene.
 Reordering based on a `HitObject` is particularly useful in situations with
 highly incoherent hits, e.g., in path tracing applications.
 
-`TryReorderThread` is available only in shaders of type `raygeneration`.
+`MaybeReorderThread` is available only in shaders of type `raygeneration`.
 
 This function introduces a [Reorder Point](#reorder-points).
 
 #### Example 1
 
 The following example shows a common pattern of combining `HitObject` and
-`TryReorderThread`:
+`MaybeReorderThread`:
 
 ```C++
 // Trace a ray without invoking closesthit/miss shading.
 HitObject hit = HitObject::TraceRay( ... );
 
 // Reorder by hit point to increase coherence of subsequent shading.
-TryReorderThread( hit );
+MaybeReorderThread( hit );
 
 // Invoke shading.
 HitObject::Invoke( hit, ... );
@@ -691,9 +691,9 @@ HitObject::Invoke( hit, ... );
 
 ---
 
-#### TryReorderThread with HitObject
+#### MaybeReorderThread with HitObject
 
-This variant of `TryReorderThread` reorders calling threads based on the
+This variant of `MaybeReorderThread` reorders calling threads based on the
 information contained in a `HitObject`.
 
 It is implementation defined which `HitObject` properties are taken into
@@ -701,17 +701,17 @@ account when defining the ordering. For example, an implementation may decide
 to order threads with respect to their hit group index, hit locations in
 3d-space, or other factors.
 
-`TryReorderThread` may access both information about the instance in the
+`MaybeReorderThread` may access both information about the instance in the
 acceleration structure as well as the shader record at the shader table
 offset contained in the `HitObject`. The respective fields in the `HitObject`
 must therefore represent valid instances and shader table offsets.
 NOP-HitObjects is an exception, which do not contain information about a hit
-or a miss, but are still legal inputs to `TryReorderThread`. Similarly, a
+or a miss, but are still legal inputs to `MaybeReorderThread`. Similarly, a
 `HitObject` constructed from a `RayQuery` but did not set a shader table
 index is exempt from having a valid shader table record.
 
 ```C++
-void TryReorderThread( HitObject Hit );
+void MaybeReorderThread( HitObject Hit );
 ```
 
 Parameter                           | Definition
@@ -720,9 +720,9 @@ Parameter                           | Definition
 
 ---
 
-#### TryReorderThread with coherence hint
+#### MaybeReorderThread with coherence hint
 
-This variant of `TryReorderThread` reorders threads based on a generic
+This variant of `MaybeReorderThread` reorders threads based on a generic
 user-provided hint. Similarity of hint values should indicate expected
 similarity of subsequent work being performed by threads. More significant
 bits of the hint value are more important than less significant bits for
@@ -734,19 +734,19 @@ significant bits. The thread ordering resulting from this call may be
 approximate.
 
 ```C++
-void TryReorderThread( uint CoherenceHint, uint NumCoherenceHintBitsFromLSB );
+void MaybeReorderThread( uint CoherenceHint, uint NumCoherenceHintBitsFromLSB );
 ```
 
 Parameter                           | Definition
 ---------                           | ----------
 `uint CoherenceHint` | User-defined value that determines the desired ordering of a thread relative to others.
-`uint NumCoherenceHintBitsFromLSB` | Indicates how many of the least significant bits in `CoherenceHint` the implementation should try to take into account. Applications should set this to the lowest value required to represent all possible values of `CoherenceHint` (at the given `TryReorderThread` call site). All threads should provide the same value at a given call site to achieve best performance.
+`uint NumCoherenceHintBitsFromLSB` | Indicates how many of the least significant bits in `CoherenceHint` the implementation should try to take into account. Applications should set this to the lowest value required to represent all possible values of `CoherenceHint` (at the given `MaybeReorderThread` call site). All threads should provide the same value at a given call site to achieve best performance.
 
 ---
 
-#### TryReorderThread with HitObject and coherence hint
+#### MaybeReorderThread with HitObject and coherence hint
 
-This variant of `TryReorderThread` reorders threads based on the information
+This variant of `MaybeReorderThread` reorders threads based on the information
 contained in a `HitObject`, supplemented by additional information expressed
 as a user-defined hint. The user-provided hint should mainly map properties
 that an implementation cannot infer from the `HitObject` itself. This can
@@ -764,12 +764,12 @@ coherence hint to reduce divergence from important branches within closesthit
 shaders, like the aforementioned material traits.
 
 Note that the number of coherence hint bits that the implementation actually
-honors can be smaller in this overload of `TryReorderThread` compared to the one
+honors can be smaller in this overload of `MaybeReorderThread` compared to the one
 described in
-[TryReorderThread with coherence hint](#TryReorderThread-with-coherence-hint).
+[MaybeReorderThread with coherence hint](#MaybeReorderThread-with-coherence-hint).
 
 ```C++
-void TryReorderThread( HitObject Hit,
+void MaybeReorderThread( HitObject Hit,
                     uint CoherenceHint,
                     uint NumCoherenceHintBitsFromLSB );
 ```
@@ -778,7 +778,7 @@ Parameter                           | Definition
 ---------                           | ----------
 `HitObject Hit` | `HitObject` that encapsulates the hit or miss according to which reordering should be performed.
 `uint CoherenceHint` | User-defined value that determines the desired ordering of a thread relative to others.
-`uint NumCoherenceHintBitsFromLSB` | Indicates how many of the least significant bits in `CoherenceHint` the implementation should try to take into account. Applications should set this to the lowest value required to represent all possible values of `CoherenceHint` (at the given `TryReorderThread` call site). All threads should provide the same value at a given call site to achieve best performance.
+`uint NumCoherenceHintBitsFromLSB` | Indicates how many of the least significant bits in `CoherenceHint` the implementation should try to take into account. Applications should set this to the lowest value required to represent all possible values of `CoherenceHint` (at the given `MaybeReorderThread` call site). All threads should provide the same value at a given call site to achieve best performance.
 
 ---
 
@@ -807,7 +807,7 @@ for( int bounceCount=0; ; bounceCount++ )
 
     // Reorder based on the hit, while taking into account how likely we are to
     // exit the loop this round.
-    TryReorderThread( hit, coherenceHints, 1 );
+    MaybeReorderThread( hit, coherenceHints, 1 );
 
     // Invoke shading for the current hit. Due to the reordering performed
     // above, this will have increased coherence.
@@ -856,7 +856,7 @@ for( int bounceCount=0; ; bounceCount++ )
     // shader ID represented by the hitobject. This is as opposed to coherence
     // hint bits, which have lower priority than the shader ID during
     // reordering.
-    TryReorderThread( hit );
+    MaybeReorderThread( hit );
 
     // Now that we've reordered, break non-participating threads out of the
     // loop.
@@ -903,13 +903,13 @@ shaders. In the case of multiple `anyhit` or `intersection` shader
 invocations, each shader stage transition is a separate reorder point.
 - `HitObject::Invoke`: transitions to and from `closeshit` and `miss` shaders.
 Constitutes a reorder point even in cases where no shader is invoked.
-- `TryReorderThread`: the `TryReorderThread` call site.
+- `MaybeReorderThread`: the `MaybeReorderThread` call site.
 
-`TryReorderThread` stands out as it explicitly separates reordering from a
+`MaybeReorderThread` stands out as it explicitly separates reordering from a
 transition between shader stages, thus, it allows applications to (carefully)
 choose the most effective reorder locations given a specific workload. The
 combination of `HitObject` and coherence hints provides additional control
-over the reordering itself. These characteristics make `TryReorderThread` a
+over the reordering itself. These characteristics make `MaybeReorderThread` a
 versatile tool for improving performance in a variety of workloads that suffer
 from divergent execution or data access.
 
@@ -925,21 +925,21 @@ scenarios.
 
 While it is understood that reordering at `TraceRay` and `CallShader` is done
 at the discretion of the driver, `HitObject::TraceRay` and `HitObject::Invoke`
-are intended to be used in conjunction with `TryReorderThread`.
+are intended to be used in conjunction with `MaybeReorderThread`.
 Reordering at `HitObject::TraceRay` and `HitObject::Invoke` is permitted but the
 driver should minimize its efforts to reorder for hit coherence and instead
-prioritize reordering through `TryReorderThread`.
+prioritize reordering through `MaybeReorderThread`.
 
 Some implementations may achieve best performance when `HitObject::TraceRay`,
-`TryReorderThread`, and `HitObject::Invoke` are called back-to-back.
+`MaybeReorderThread`, and `HitObject::Invoke` are called back-to-back.
 This case is semantically equivalent to DXR 1.0 `TraceRay` but with defined
 reordering characteristics.
-The back-to-back combination of `TryReorderThread` and `HitObject::Invoke` may
+The back-to-back combination of `MaybeReorderThread` and `HitObject::Invoke` may
 similarly see a performance benefit on some implementations.
 
 For performance reasons, it is crucial that the DXIL-generating compiler does
 not move non-uniform resource access across reorder points in general, and across
-`TryReorderThread` in particular. It should be assumed that the shader will perform
+`MaybeReorderThread` in particular. It should be assumed that the shader will perform
 the access where coherence is maximized.
 
 ---
@@ -963,19 +963,19 @@ int MyFunc(int coherenceCoord)
 {
     int A = WaveActiveBallot(true);
     if (WaveIsFirstLane())
-        TryReorderThread(coherenceCoord, 32);
+        MaybeReorderThread(coherenceCoord, 32);
     int B = WaveActiveBallot(true);
     return A - B;
 }
 ```
 
 In this example, a number of different things could happen:
-- If the implementation does not honor `TryReorderThread` at all, the function
+- If the implementation does not honor `MaybeReorderThread` at all, the function
 will most likely return zero, as the set of threads before and after the
 conditional reorder would be the same.
-- If the implementation reorders threads invoking `TryReorderThread` but does not
+- If the implementation reorders threads invoking `MaybeReorderThread` but does not
 replace them, B will likely be less than A for threads not invoking
-`TryReorderThread`, while the reordered threads will likely resume execution with
+`MaybeReorderThread`, while the reordered threads will likely resume execution with
 a newly formed full wave, thereby obtaining `A <= B`.
 - If the implementation replaces threads in a wave, the threads not
 participating in the reorder may possibly be joined by more threads than were
@@ -1000,7 +1000,7 @@ UAV reads, the following steps are required:
 2. The UAV writer must issue a `Barrier(UAV_MEMORY, REORDER_SCOPE)` between the write and the reorder point.
 
 Note that these steps are required to ensure coherence across any reorder point.
-For example, between a write performed before `TryReorderThread` or `TraceRay` and a
+For example, between a write performed before `MaybeReorderThread` or `TraceRay` and a
 subsequent read in the same shader, or between shader stages (such as data written
 in the closesthit shader and read in the raygeneration shader).
 
@@ -1011,14 +1011,14 @@ Instead, global coherency can be utilized as follows:
 2. The UAV writer must issue a `DeviceMemoryBarrier` between the write and the
 reorder point.
 
-## Separation of TryReorderThread and HitObject::Invoke
+## Separation of MaybeReorderThread and HitObject::Invoke
 
-`TryReorderThread` and `HitObject::Invoke` are kept separate. It enables calling
-`TryReorderThread` without `HitObject::Invoke`, and `HitObject::Invoke` without
-calling `TryReorderThread`. These are valid use cases as reordering can be
+`MaybeReorderThread` and `HitObject::Invoke` are kept separate. It enables calling
+`MaybeReorderThread` without `HitObject::Invoke`, and `HitObject::Invoke` without
+calling `MaybeReorderThread`. These are valid use cases as reordering can be
 beneficial even when shading happens inline in the raygeneration shader, and
 reordering before a known to be coherent or cheap shader can be
-counterproductive. For cases in which both is desired, keeping `TryReorderThread`
+counterproductive. For cases in which both is desired, keeping `MaybeReorderThread`
 and `HitObject::Invoke` separated is still beneficial as detailed below.
 
 Common hit processing can happen in the raygeneration shader with the
@@ -1026,7 +1026,7 @@ additional efficiency gains of hit coherence. Benefits include:
 - Logic otherwise duplicated can be hoisted into the raygeneration shader
 without a loss of hit coherence. This can reduce instruction cache pressure
 and reduce compile times.
-- Logic between `TryReorderThread` and `HitObject::Invoke` have access to the
+- Logic between `MaybeReorderThread` and `HitObject::Invoke` have access to the
 full state of the raygeneration shader. It can access a large material stack
 keeping track of surface boundaries, for example. This is difficult or
 impossible to communicate through the payload.
@@ -1038,13 +1038,13 @@ common light sampling. On a second bounce a shadow map lookup may be enough.
 
 In addition to the above, API complexity is reduced by only having separate
 calls, as opposed to both separate calls and a fused variant. Further,
-`TryReorderThread` naturally communicates a reorder point, when hit-coherent
+`MaybeReorderThread` naturally communicates a reorder point, when hit-coherent
 execution starts and that it will persist after the call (until the next
 reorder point). Reasoning about the execution and that it is hit-coherent is
 not as obvious after a call to a hypothetical (fused)
 `HitObject::ReorderAndInvoke`. Finally, tools can report live state across
-`TryReorderThread` and users can optimize live state across it. This is important
-as live state across `TryReorderThread` may be more expensive on some
+`MaybeReorderThread` and users can optimize live state across it. This is important
+as live state across `MaybeReorderThread` may be more expensive on some
 architectures.
 
 Some examples follow.
@@ -1067,7 +1067,7 @@ uint iorListSize = 0;
 for( ... )
 {
     HitObject hit = HitObject::TraceRay( ... );
-    TryReorderThread( hit );
+    MaybeReorderThread( hit );
 
     IorData newEntry = LoadIorDataFromHit( hit );
     bool enter = hit.GetHitKind() == HIT_KIND_TRIANGLE_FRONT_FACE;
@@ -1085,7 +1085,7 @@ the thread has been reordered for hit coherence.
 
 ```C++
 hit = HitObject::TraceRay( ... );
-TryReorderThread( hit );
+MaybeReorderThread( hit );
 
 payload.giData = GlobalIlluminationCacheLookup( hit );
 
@@ -1102,7 +1102,7 @@ using the same shader code.
 // reorder for hit coherence as it is coherent enough.
 ray = GeneratePrimaryRay();
 hit = HitObject::TraceRay( ... );
-// NOTE: Although TryReorderThread is not explicitly invoked here,
+// NOTE: Although MaybeReorderThread is not explicitly invoked here,
 // reordering can still occur at any reorder point based on
 // driver-specific decisions.
 RayDesc shadowRay = SampleShadow( hit );
@@ -1112,7 +1112,7 @@ HitObject::Invoke( hit, payload );
 // Secondary ray is incoherent but does not need perfect shadows.
 ray = ContinuePath( payload );
 hit = HitObject::TraceRay( ... );
-TryReorderThread( hit );
+MaybeReorderThread( hit );
 payload.shadowTerm = SampleShadowMap( hit );
 HitObject::Invoke( hit, payload );
 ```
@@ -1125,7 +1125,7 @@ improve data coherence.
 ```C++
 hit = HitObject::TraceRay( ... );
 
-TryReorderThread( hit );
+MaybeReorderThread( hit );
 
 // Do not call HitObject::Invoke. Shade in raygeneration.
 ```
@@ -1136,14 +1136,14 @@ Executing the miss shader when not needed is unnecessarily inefficient
 on some architectures. In this example, miss shader execution is skipped.
 
 Note that behavior can vary. Other architectures may have better efficiency
-when `HitObject::TraceRay`, `TryReorderThread` and `HitObject::Invoke` are
+when `HitObject::TraceRay`, `MaybeReorderThread` and `HitObject::Invoke` are
 called back-to-back (see [Reorder Points](#reorder-points)).
 
 ```C++
 for( ;; )
 {
     hit = HitObject::TraceRay( ... );
-    TryReorderThread( hit );
+    MaybeReorderThread( hit );
 
     if( hit.IsMiss() )
         break;
@@ -1160,7 +1160,7 @@ This approach can help reduce shader permutations.
 
 ```C++
 hit = HitObject::TraceRay( ... );
-TryReorderThread( hit );
+MaybeReorderThread( hit );
 
 // Gather surface parameters into payload, e.g., compute normal and albedo
 // based on surface-specific functions and/or textures.
@@ -1179,10 +1179,10 @@ HitObject::Invoke( hit, payload );
 ### Example: Live state optimization
 
 In this example, logic is added to compress and uncompress part of the
-payload across `TryReorderThread`.
-This can make sense if live state is more expensive across `TryReorderThread`.
+payload across `MaybeReorderThread`.
+This can make sense if live state is more expensive across `MaybeReorderThread`.
 
-Some implementations may favor cases where `HitObject::TraceRay`, `TryReorderThread`
+Some implementations may favor cases where `HitObject::TraceRay`, `MaybeReorderThread`
 and `HitObject::Invoke` are called back-to-back (see [Reorder Points](#reorder-points)),
 so performance profiling is necessary.
 
@@ -1190,7 +1190,7 @@ so performance profiling is necessary.
 hit = HitObject::TraceRay( ... );
 
 uint compressedNormal = CompressNormal( payload.normal );
-TryReorderThread( hit );
+MaybeReorderThread( hit );
 payload.normal = UncompressNormal( compressedNormal );
 
 HitObject::Invoke( hit, payload );
@@ -1199,7 +1199,7 @@ HitObject::Invoke( hit, payload );
 ### Example: Back-to-back calls
 
 This example demonstrates the back-to-back arrangement of `HitObject::TraceRay`,
-`TryReorderThread`, and `HitObject::Invoke`.
+`MaybeReorderThread`, and `HitObject::Invoke`.
 For some architectures, this arrangement is the most efficient, as it can be
 recognized as a single reorder point, reducing call overhead
 (see [Reorder Points](#reorder-points)).
@@ -1207,7 +1207,7 @@ Additional logic between these calls should only be added when necessary.
 
 ```C++
 hit = HitObject::TraceRay( ... );
-TryReorderThread( hit );
+MaybeReorderThread( hit );
 HitObject::Invoke( hit, payload );
 ```
 
@@ -1244,7 +1244,7 @@ XXX + 2  | HitObject_FromRayQueryWithAttrs | Creates a new `HitObject` represent
 XXX + 3  | HitObject_MakeMiss | Creates a new `HitObject` representing a miss.
 XXX + 4  | HitObject_MakeNop | Creates an empty nop `HitObject`.
 XXX + 5  | HitObject_Invoke | Represents the invocation of the CH/MS shader represented by the `HitObject`.
-XXX + 6  | TryReorderThread | Reorders the current thread. Optionally accepts a `HitObject` arg, or `undef`.
+XXX + 6  | MaybeReorderThread | Reorders the current thread. Optionally accepts a `HitObject` arg, or `undef`.
 XXX + 7  | HitObject_IsMiss | Returns `true` if the `HitObject` represents a miss.
 XXX + 8  | HitObject_IsHit | Returns `true` if the `HitObject` represents a hit.
 XXX + 9  | HitObject_IsNop | Returns `true` if the `HitObject` is a NOP-HitObject.
@@ -1390,15 +1390,15 @@ Validation errors:
 - Validate the compatibility of type `PayloadT`.
 - Validate that `payload` is a valid pointer.
 
-#### TryReorderThread
+#### MaybeReorderThread
 
 Operation that reorders the current thread based on the supplied hints and
 `HitObject`. The canonical lowering of the
-HLSL intrinsic `TryReorderThread( uint CoherenceHint, uint NumCoherenceHintBitsFromLSB )`
+HLSL intrinsic `MaybeReorderThread( uint CoherenceHint, uint NumCoherenceHintBitsFromLSB )`
 uses `undef` for the `HitObject` parameter.
 
 ```DXIL
-declare void @dx.op.TryReorderThread(
+declare void @dx.op.MaybeReorderThread(
     i32,                      ; opcode
     %dx.types.HitObject,      ; hit object
     i32,                      ; coherence hint
@@ -1407,7 +1407,7 @@ declare void @dx.op.TryReorderThread(
 ```
 
 Validation errors:
-- Validate that `opcode` equals `TryReorderThread`.
+- Validate that `opcode` equals `MaybeReorderThread`.
 - Validate that `coherence hint` is not undef.
 - Validate that `num coherence hint bits from LSB` is not undef.
 


### PR DESCRIPTION
As noted by @Jasper-Bekkers in [this comment](https://github.com/microsoft/hlsl-specs/pull/277#issuecomment-2616782435), "MaybeReorderThread" may a better name to make it clear that some implementations may not actually reorder threads at this point.