### PR TITLE
Require SER support on any SM 6.9 device with raytracing support.

### DIFF
--- a/proposals/0027-shader-execution-reordering.md
+++ b/proposals/0027-shader-execution-reordering.md
@@ -98,6 +98,15 @@ query information about the hit to influence `ReorderThread` with additional
 hints. See [Separation of ReorderThread and HitObject::Invoke](#separation-of-reorderthread-and-hitobjectinvoke)
 for more elaborate examples.
 
+`TraceRay` returning a `HitObject` can be called on its own as well without
+calling `ReorderThread` or `Invoke`.  The caller might just want a `HitObject` 
+without caring about thread reordering or Closesthit or miss shading. 
+This is discussed in [Device Support](#device-support), in particular
+the implication given that SER is required as part of Shader Model 6.9 for 
+raytracing capable devices: Even for devices that only trivially support SER 
+by doing nothing on `ReorderThread` must also support `Invoke` not being called,
+essentially a new capability to skip final shading not available before.
+
 ### HitObject HLSL Additions
 
 ```C++


### PR DESCRIPTION
- Require devices that support SM 6.9 and raytracing to support SER, whether it can reorder or not.  If not, ReorderThread() is just a no-op.
- Expose D3D runtime cap indicating BOOL ShaderExecutionReorderingActuallyReorders
- Example of using SER to just TraceRay without Invoke() as a way to just get T value from the HitObject without running ClosestHit/Miss. This works on any device.