### PR TITLE
[SER] Add CommittedCustomHitKind to HitObject::FromRayQuery

### DIFF
--- a/proposals/0027-shader-execution-reordering.md
+++ b/proposals/0027-shader-execution-reordering.md
@@ -177,10 +177,10 @@ If no hit is committed in the RayQuery,
 the HitObject returned is a NOP-HitObject. A shader table record can be assigned
 separately, which in turn allows invoking a shader.
 
-An overload takes custom attributes associated with
-COMMITTED_PROCEDURAL_PRIMITIVE_HIT. It is ok to always use the overload, even
-for COMMITTED_TRIANGLE_HIT. For anything other than a procedural hit, the
-specified attributes are ignored.
+An overload takes a user-defined hit kind and custom attributes associated with
+COMMITTED_PROCEDURAL_PRIMITIVE_HIT (see `ReportHit` for details).
+It is ok to always use the overload, even for COMMITTED_TRIANGLE_HIT. For anything
+other than a procedural hit, the specified hit kind and attributes are ignored.
 
 ```C++
 static HitObject HitObject::FromRayQuery(
@@ -189,6 +189,7 @@ static HitObject HitObject::FromRayQuery(
 template<attr_t>
 static HitObject HitObject::FromRayQuery(
     RayQuery Query,
+    uint CommittedCustomHitKind,
     attr_t CommittedCustomAttribs);
 ```
 
@@ -1326,10 +1327,11 @@ Validation errors:
 declare %dx.types.HitObject @dx.op.hitObject_FromRayQuery.AttrT(
     i32,                           ; opcode
     i32,                           ; ray query
+    i32,                           ; hit kind
     AttrT*)                        ; attributes
     nounwind argmemonly
 ```
-This is used for the HLSL overload of `HitObject::FromRayQuery` that takes `RayQuery` and the user-defined `Attribute` struct.
+This is used for the HLSL overload of `HitObject::FromRayQuery` that takes `RayQuery`, a user-defined hit kind, and `Attribute` struct.
 `AttrT` is the user-defined intersection attribute struct type. See `ReportHit` for definition.
 
 Validation errors:
@@ -1337,6 +1339,9 @@ Validation errors:
 - Validate that `ray query` is a valid ray query handle.
 - Validate the compatibility of type `AttrT`.
 - Validate that `attributes` is a valid pointer.
+
+Validation warnings:
+- Validate that `hit kind` is in the range of 0-127.
 
 #### HitObject_MakeMiss
 

--- a/proposals/0027-shader-execution-reordering.md
+++ b/proposals/0027-shader-execution-reordering.md
@@ -1325,7 +1325,7 @@ Validation errors:
 #### HitObject_FromRayQueryWithAttrs
 
 ```DXIL
-declare %dx.types.HitObject @dx.op.hitObject_FromRayQuery.AttrT(
+declare %dx.types.HitObject @dx.op.hitObject_FromRayQueryWithAttrs.AttrT(
     i32,                           ; opcode
     i32,                           ; ray query
     i32,                           ; hit kind

--- a/proposals/0027-shader-execution-reordering.md
+++ b/proposals/0027-shader-execution-reordering.md
@@ -178,7 +178,7 @@ the HitObject returned is a NOP-HitObject. A shader table record can be assigned
 separately, which in turn allows invoking a shader.
 
 An overload takes a user-defined hit kind and custom attributes associated with
-COMMITTED_PROCEDURAL_PRIMITIVE_HIT (see `ReportHit` for details).
+COMMITTED_PROCEDURAL_PRIMITIVE_HIT.
 It is ok to always use the overload, even for COMMITTED_TRIANGLE_HIT. For anything
 other than a procedural hit, the specified hit kind and attributes are ignored.
 
@@ -197,6 +197,7 @@ Parameter                           | Definition
 ---------                           | ----------
 `Return: HitObject` | The `HitObject` that contains the result of the initialization operation.
 `RayQuery Query` | RayQuery from which the hit is created.
+`uint CommittedCustomHitKind` | See the `HitKind` parameter of `ReportHit` for definition.
 `attr_t CommittedCustomAttribs` | See the `Attributes` parameter of `ReportHit` for definition. If a closesthit shader is invoked from this `HitObject`, `attr_t` must match the attribute type of the closesthit shader.
 
 The size of `attr_t` must not exceed `MaxAttributeSizeInBytes` specified in the `D3D12_RAYTRACING_SHADER_CONFIG`.


### PR DESCRIPTION
There is currently no way to specify HitKind for a HitObject created from RayQuery with COMMITTED_PROCEDURAL_PRIMITIVE_HIT and custom attributes. This PR adds another parameter to the call to allow this.