### PR TITLE
Update version of artifact uploader

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -53,7 +53,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
       - if: ${{ github.event_name == 'pull_request'}}
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Apparently upload-pages-artifact v1 uses a depreacated version of upload-artifact. This gets our pipelines working again.