### PR TITLE
Fix missing newline in floating literal grammar

### DIFF
--- a/specs/language/lex.tex
+++ b/specs/language/lex.tex
@@ -332,7 +332,7 @@ is ill-formed.
   \texttt{e} \opt{sign} digit-sequence\br
   \texttt{E} \opt{sign} digit-sequence\br
   \define{sign} \textnormal{one of}\br
-  \texttt{+} \texttt{-}
+  \texttt{+} \texttt{-}\br
   \define{digit-sequence}\br
   digit\br
   digit-sequence digit


### PR DESCRIPTION
I discovered this formatting error when looking reviewing this as a reference.