### PR TITLE
2025-02-18 Design Meeting Agenda & Minutes

### DIFF
--- a/docs/DesignMeetingMinutes/2025-02-18.md
+++ b/docs/DesignMeetingMinutes/2025-02-18.md
@@ -34,11 +34,11 @@
 ### Current Business
 
 * [Add proposal for scalar layout for constant buffers](https://github.com/microsoft/hlsl-specs/pull/317)
-  * Call for acceptance.
+  * Call for consensus on consideration.
   * @llvm-beanz: There are details in the proposal that still need to be worked
     out, but I'm comfortable calling for acceptance and we can merge and iterate.
 * [Adding proposal for C++ constructors](https://github.com/microsoft/hlsl-specs/pull/325)
-  * Call for acceptance.
+  * Call for consensus on consideration.
   * Carried forward - Action Item: @V-FEXrt to review.
   * @llvm-beanz: There are more details here that we should fully spec out like
     the required wider changes to object initialization.

--- a/docs/DesignMeetingMinutes/2025-02-18.md
+++ b/docs/DesignMeetingMinutes/2025-02-18.md
@@ -35,10 +35,12 @@
 
 * [Add proposal for scalar layout for constant buffers](https://github.com/microsoft/hlsl-specs/pull/317)
   * Call for consensus on consideration.
+    * No objections, will be merged under-consideration once ready.
   * @llvm-beanz: There are details in the proposal that still need to be worked
     out, but I'm comfortable calling for acceptance and we can merge and iterate.
 * [Adding proposal for C++ constructors](https://github.com/microsoft/hlsl-specs/pull/325)
   * Call for consensus on consideration.
+    * No objections, will be merged under-consideration once ready.
   * Carried forward - Action Item: @V-FEXrt to review.
   * @llvm-beanz: There are more details here that we should fully spec out like
     the required wider changes to object initialization.

--- a/docs/DesignMeetingMinutes/2025-02-18.md
+++ b/docs/DesignMeetingMinutes/2025-02-18.md
@@ -1,0 +1,48 @@
+# Design Meeting Minutes: 2025/02/18
+
+> NOTE: Please read the [terms of participation](DesignMeetingTerms.txt)
+> ("Terms") prior to joining the Teams meeting.  You joining the Teams meeting
+> with Microsoft indicates your acknowledgement, agreement, and consent to these
+> Terms.  If you do not agree to these Terms, please do not join the meeting.
+>
+> If you intend to contribute code or other copyrightable materials (e.g.
+> written comments, tools, documentation, etc.)  to the hlsl specs repository,
+> you are required to sign a Contributor License Agreement (CLA).  For details,
+> visit https://cla.microsoft.com.
+
+## Administrivia
+* No topics
+
+## Issues
+* No marked issues
+* Action Item: @llvm-beanz to review issues for HLSL 202x
+
+## PRs
+
+### Carried Forward
+* [[0007] Big update to flesh out const instance methods](https://github.com/microsoft/hlsl-specs/pull/34)
+  * Action Item: @llvm-beanz update based on @tex3d's feedback
+  * Action Item: @pow2clk to review the PR and comment
+* [[0002] Specify the grammar formulations for attributes](https://github.com/microsoft/hlsl-specs/pull/65)
+  * Action Item: @pow2clk to review.
+* [[dxil] Proposal to add new debug printf dxil op](https://github.com/microsoft/hlsl-specs/pull/324)
+  * @pow2clk and @tex3d will review this in more detail.
+* [Rework hlsl-vector-type into two specs](https://github.com/microsoft/hlsl-specs/pull/361)
+  * Action Item: @llvm-beanz to review.
+* [[202y] Propose adding C++11-style constructors](https://github.com/microsoft/hlsl-specs/pull/325)
+  * Action Item: @farzonl & @V-FEXrt to review.
+* [[202x] Propose adding vk::SampledTexture* types](https://github.com/microsoft/hlsl-specs/pull/343)
+  * Action Item: @llvm-beanz to review.
+* [Add resource chapter documenting buffers and bindings](https://github.com/microsoft/hlsl-specs/pull/344)
+  * Action Item: @llvm-beanz to review.
+* [Specification language to describe flat conversions and aggregate splats](https://github.com/microsoft/hlsl-specs/pull/358)
+  * Action Item: @spall to update
+
+### Current Business
+
+* [Add proposal for scalar layout for constant buffers](https://github.com/microsoft/hlsl-specs/pull/317)
+  * Call for acceptance.
+  * @llvm-beanz: There are details in the proposal that still need to be worked
+    out, but I'm comfortable calling for acceptance and we can merge and iterate.
+
+## Other Discussion

--- a/docs/DesignMeetingMinutes/2025-02-18.md
+++ b/docs/DesignMeetingMinutes/2025-02-18.md
@@ -21,20 +21,13 @@
 
 ### Carried Forward
 * [[0007] Big update to flesh out const instance methods](https://github.com/microsoft/hlsl-specs/pull/34)
-  * Action Item: @llvm-beanz update based on @tex3d's feedback
   * Action Item: @pow2clk to review the PR and comment
 * [[0002] Specify the grammar formulations for attributes](https://github.com/microsoft/hlsl-specs/pull/65)
-  * Action Item: @pow2clk to review.
+  * Action Item: @llvm-beanz to revise.
 * [[dxil] Proposal to add new debug printf dxil op](https://github.com/microsoft/hlsl-specs/pull/324)
   * @pow2clk and @tex3d will review this in more detail.
-* [Rework hlsl-vector-type into two specs](https://github.com/microsoft/hlsl-specs/pull/361)
-  * Action Item: @llvm-beanz to review.
-* [[202y] Propose adding C++11-style constructors](https://github.com/microsoft/hlsl-specs/pull/325)
-  * Action Item: @farzonl & @V-FEXrt to review.
 * [[202x] Propose adding vk::SampledTexture* types](https://github.com/microsoft/hlsl-specs/pull/343)
-  * Action Item: @llvm-beanz to review.
-* [Add resource chapter documenting buffers and bindings](https://github.com/microsoft/hlsl-specs/pull/344)
-  * Action Item: @llvm-beanz to review.
+  * Ready to merge.
 * [Specification language to describe flat conversions and aggregate splats](https://github.com/microsoft/hlsl-specs/pull/358)
   * Action Item: @spall to update
 
@@ -44,5 +37,11 @@
   * Call for acceptance.
   * @llvm-beanz: There are details in the proposal that still need to be worked
     out, but I'm comfortable calling for acceptance and we can merge and iterate.
+* [Adding proposal for C++ constructors](https://github.com/microsoft/hlsl-specs/pull/325)
+  * Call for acceptance.
+  * Carried forward - Action Item: @V-FEXrt to review.
+  * @llvm-beanz: There are more details here that we should fully spec out like
+    the required wider changes to object initialization.
+* [Update on 202x & 202y](https://github.com/microsoft/hlsl-specs/pull/391)
 
 ## Other Discussion


### PR DESCRIPTION
This PR represents the planned agenda for the 2025-02-18 design meeting and will become the meeting minutes after the meeting occurs.