### PR TITLE
[0029] Remove HLSL API from Cooperative Vector proposal

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -24,9 +24,8 @@ accelerate neural network computations, like accelerating matrix operations.
 
 This proposal introduces DXIL operations for vector-matrix operations that can
 be accelerated by the underlying hardware, building on support for long vectors
-described in proposals [0026] and [0030]. This proposal describes HLSL builtins
-that can be used for example and testing purposes as well as the building blocks
-for a high-level HLSL API. The high-level API is described in proposal \[TBD\].
+described in proposals [0026] and [0030]. The high-level API is described in
+proposal \[TBD\].
 
 [0026]: 0026-hlsl-long-vector-type.md
 [0030]: 0030-dxil-vectors.md
@@ -159,7 +158,7 @@ stored in a variable.
 The `@dx.op.matvecmuladd` operation behaves as `@dx.op.matvecmul`, but also adds
 an **M**-sized bias vector (loaded from memory) to the result.
 
-> Note that the dimensions of the matrix are **M**x**K** versus **M**x**N**
+> Note that the dimensions of the matrix are **M**x**K** versus the **M**x**N**
 > usually found in linear algebra textbooks. This is to futureproof for
 > potential matrix-matrix operations in the future where the inputs could be
 > **M**x**K** and **K**x**N** to produce an **M**x**N** result matrix.
@@ -173,8 +172,8 @@ The **input vector** is of size `NUMi` and contains elements of physical type
 the vector. `NUMi` has a relationship with **K** as follows:
 
 * for non-packed interpretations: `NUMi` equals **K**,
-* for packed interpretations: `NUMi` equals the least number that can hold **K**
-  values of the packed type.
+* for packed interpretations: `NUMi` equals the smallest number that can hold
+  **K** values of the packed type.
 
 Non-packed interpretations are standard types such as float16, uint etc.  Packed
 types are types such as **SignedInt8x4Packed** where each 32-bit element of the
@@ -253,8 +252,8 @@ aligned.
 
 Not all combinations of vector element type and matrix interpretations are
 supported by all implementations. [CheckFeatureSupport] can be used to determine
-which combinations. A list of combinations that are guaranteed to be supported
-on all implementations can be found in [Minimum Support Set].
+which combinations are supported. A list of combinations that are guaranteed to
+be supported on all implementations can be found in [Minimum Support Set].
 
 
 ### Reduce Sum Accumulate
@@ -330,8 +329,7 @@ into multiple logical elements.
 **bias vector interpretation** and **TYo** are supported on a particular
 implementation. A list of combinations that are guaranteed to be supported on
 all implementations can be found in [Minimum Support Set]. Note that there is no
-guaranteed support for **matrix tranpose**, and so it must always queried. s
-queried.
+guaranteed support for **matrix tranpose**, and so it must always be queried.
 
 #### Conversation Rules
 

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -123,35 +123,35 @@ Introduce new DXIL operations to accelarate matrix-vector operations. In this sp
 
 ``` llvm 
 declare <[NUMo] x [TYo] @dx.op.matvecmul.v[NUMo][TYo].v[NUMi][TYi](
-    i32               ; opcode
+    immarg i32        ; opcode
     <[NUMi] x [TYi]>, ; input vector
-    i32,              ; input interpretation
+    immarg i32,       ; input interpretation
     %dx.types.Handle, ; matrix resource
     i32,              ; matrix offset
-    i32,              ; matrix interpretation
-    i32,              ; matrix M dimension    
-    i32,              ; matrix K dimension    
-    i32,              ; matrix layout
-    i32,              ; matrix transpose      <<< should this be i1?
+    immarg i32,       ; matrix interpretation
+    immarg i32,       ; matrix M dimension    
+    immarg i32,       ; matrix K dimension    
+    immarg i32,       ; matrix layout
+    immarg i32,       ; matrix transpose      <<< should this be i1?
     i32,              ; matrix stride
-    i1)               ; isResultSigned        <<< what is this for?
+    immarg i1)        ; isResultSigned        <<< See #399
 
 declare <[NUMo] x [TYo]> @dx.op.matvecmuladd.v[NUMo][TYo].v[NUMi][TYi](
-    i32               ; opcode
+    immarg i32        ; opcode
     <[NUMi] x [TYi]>, ; input vector
-    i32,              ; input interpretation
+    immarg i32,       ; input interpretation
     %dx.types.Handle, ; matrix resource
     i32,              ; matrix offset
-    i32,              ; matrix interpretation
-    i32,              ; matrix M dimension    
-    i32,              ; matrix K dimension    
-    i32,              ; matrix layout
-    i32,              ; matrix transpose      <<< should this be i1?
+    immarg i32,       ; matrix interpretation
+    immarg i32,       ; matrix M dimension    
+    immarg i32,       ; matrix K dimension    
+    immarg i32,       ; matrix layout
+    immarg i32,       ; matrix transpose      <<< should this be i1?
     i32,              ; matrix stride
     %dx.types.Handle, ; bias vector resource
     i32,              ; bias vector offset
-    i32,              ; bias vector interpretation
-    i1)               ; isResultSigned        <<< what is this for?
+    immarg i32,       ; bias vector interpretation
+    immarg i1)        ; isResultSigned        <<< See #399
 ```
 
 #### Overview
@@ -164,11 +164,13 @@ The `@dx.op.matvecmuladd` operation behaves as `@dx.op.matvecmul`, but also adds
 an **M**-sized bias vector (loaded from memory) to the result.
 
 > Note that the dimensions of the matrix are **M**x**K** versus **M**x**N**
-> usually found in linear algebra texbooks. This is to futureproof for potential
-> matrix-matrix operations in the future where the inputs could be **M**x**K**
-> and **K**x**N** to produce an **M**x**N** result matrix.
+> usually found in linear algebra textbooks. This is to futureproof for
+> potential matrix-matrix operations in the future where the inputs could be
+> **M**x**K** and **K**x**N** to produce an **M**x**N** result matrix.
 
 #### Arguments
+
+| Argument | Type | 
 
 ##### Input Vector
 
@@ -212,7 +214,6 @@ aligned.
 
 ##### Bias Matrix
 
-> * TODO: alignment requirements for **bias vector offset**
 > * TODO: are packed types allowed for bias vectors?
 
 The bias matrix is loaded from the raw-buffer, **bias vector resource**,
@@ -229,14 +230,14 @@ The base address of **bias vector resource** and **bias vector offset** must be
 
 ``` llvm
 declare void @dx.op.vecouterproductacc.v[M][TY].v[N][TY](
-    i32,              ; opcode 
+    immarg i32,       ; opcode 
     <[M] x [TY]>,     ; input vector 1
     <[N] x [TY]>,     ; input vector 2
     %dx.types.Handle, ; matrix resource
     i32,              ; matrix offset 
     i32,              ; matrix stride 
-    i32,              ; matrix interpretation 
-    i32)              ; matrix layout 
+    immarg i32,       ; matrix interpretation 
+    immarg i32)       ; matrix layout 
 ```
 
 #### Overview
@@ -273,7 +274,7 @@ on all implementations can be found in [Minimum Support Set].
 
 ``` llvm
 declare void @dx.op.vecreducesumacc.v[NUM][TY](
-    i32,              ; opcode
+    immarg i32,       ; opcode
     <[NUM] x [TY]>,   ; input vector
     %dx.types.Handle, ; output array resource 
     i32)              ; output array offset

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -21,7 +21,7 @@ use of GPUs for general purpose ML/DL means that GPU vendors continue to add mor
 accelerate neural network computations, like accelerating matrix operations.
 
 This proposal introduces DXIL operations for vector-matrix operations that can
-accelerated by the underlying hardware, building on support for long verctors
+be accelerated by the underlying hardware, building on support for long vectors
 described in proposals [0026] and [0030]. This proposal describes HLSL builtins
 that can be used for example and testing purposes as well as the building blocks
 for a high-level HLSL API. The high-level API is described in proposal \[TBD\].

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -115,12 +115,6 @@ Introduce new DXIL operations to accelarate matrix-vector operations. In this sp
 
 #### Syntax
  
-> NOTES FOR REVIEW, REMOVE BEFORE MERGING: 
->  
-> Added @dx.op.matvecmuladd version, and also renamed  from
-> @dx.op.vecmatmul[add] to @dx.op.matvecmul[add] since it is a left matrix
-> multiply.
-
 ``` llvm 
 declare <[NUMo] x [TYo] @dx.op.matvecmul.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32        ; opcode

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -200,13 +200,13 @@ The base address of **matrix resource** and **matrix offset** must be 64 byte
 aligned.
 
 
-##### Bias Matrix
+##### Bias Vector
 
-> * TODO: are packed types allowed for bias vectors?
-
-The bias matrix is loaded from the raw-buffer, **bias vector resource**,
+The bias vector is loaded from the raw-buffer, **bias vector resource**,
 starting at **bias vector offset**. The **bias vector interpretation** argument
 specifies the element type of the bias vector (see [Type Interpretations]).
+
+Only non-packed interpretations are valid for bias vectors.
 
 The base address of **bias vector resource** and **bias vector offset** must be
 64 byte aligned.

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -166,8 +166,6 @@ an **M**-sized bias vector (loaded from memory) to the result.
 
 #### Arguments
 
-| Argument | Type | 
-
 ##### Input Vector
 
 The **input vector** is of size `NUMi` and contains elements of physical type

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -3,7 +3,9 @@
 * Proposal: [0029](0029-cooperative-vector.md)
 * Author(s): [Anupama Chandrasekhar][anupamachandra]
 * Sponsor: [Damyan Pepper][damyanp], [Greg Roth][pow2clk]
-* Status: **Under Consideration**
+* Status: **Under Review**
+* Planned Version: Shader Model 6.9
+
 
 [anupamachandra]: https://github.com/anupamachandra
 [damyanp]: https://github.com/damyanp

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -442,8 +442,6 @@ Matrix Transpose and Bias, Bias Offset, Bias Interpretation, but this is not a r
 
 The vector-matrix intrinsics are expected to be supported in all shader stages.
 
-> TODO: Add query to determine which shader stages support these intrinsics.
-
 ### Diagnostic Changes
 
 * Diagnostics for incorrect use of the new intrinsics.

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -126,7 +126,7 @@ declare <[NUMo] x [TYo] @dx.op.matvecmul.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32,       ; matrix M dimension    
     immarg i32,       ; matrix K dimension    
     immarg i32,       ; matrix layout
-    immarg i32,       ; matrix transpose      <<< should this be i1?
+    immarg i1,        ; matrix transpose
     i32,              ; matrix stride
     immarg i1)        ; isResultSigned        <<< See #399
 
@@ -140,7 +140,7 @@ declare <[NUMo] x [TYo]> @dx.op.matvecmuladd.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32,       ; matrix M dimension    
     immarg i32,       ; matrix K dimension    
     immarg i32,       ; matrix layout
-    immarg i32,       ; matrix transpose      <<< should this be i1?
+    immarg i1,        ; matrix transpose
     i32,              ; matrix stride
     %dx.types.Handle, ; bias vector resource
     i32,              ; bias vector offset

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -200,12 +200,6 @@ The base address of **matrix resource** and **matrix offset** must be 64 byte
 aligned.
 
 
-
-> TODO: consider using a different set of interpretation values for in-memory
-> interpretations versus vector interpretations.
-
-
-
 ##### Bias Matrix
 
 > * TODO: are packed types allowed for bias vectors?

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -1,7 +1,8 @@
 <!-- {% raw %} -->
 
 * Proposal: [0029](0029-cooperative-vector.md)
-* Author(s): [Anupama Chandrasekhar][anupamachandra], [Damyan Pepper][damyanp]
+* Author(s): [Anupama Chandrasekhar][anupamachandra], [Damyan Pepper][damyanp],
+             [Shashank Wadhwa][shashankw]
 * Sponsor: [Damyan Pepper][damyanp], [Greg Roth][pow2clk]
 * Status: **Under Review**
 * Planned Version: Shader Model 6.9
@@ -10,6 +11,7 @@
 [anupamachandra]: https://github.com/anupamachandra
 [damyanp]: https://github.com/damyanp
 [pow2clk]: https://github.com/pow2clk
+[shashankw]: https://github.com/shashankw
 
 # Cooperative Vectors
 

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -416,10 +416,10 @@ optimal layout. Row-Major and Column-Major layouts are also supported.
 ### Matrix Transpose
 
 The **matrix transpose** parameter indicates if the matrix is transposed before
-performing the multiply. In linear algebra,
-the[transpose](https://en.wikipedia.org/wiki/Transpose) of a matrix is an
-operator which flips a matrix over its diagonal; that is, it switches the row
-and column indices of the matrix. 
+performing the multiply. In linear algebra, the
+[transpose](https://en.wikipedia.org/wiki/Transpose) of a matrix is an operator
+which flips a matrix over its diagonal; that is, it switches the row and column
+indices of the matrix. 
 
 Transposing is not supported for the RowMajor/ColumnMajor layouts. 
 

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -230,7 +230,8 @@ declare void @dx.op.vecouterproductacc.v[M][TY].v[N][TY](
 
 #### Overview
 
-Computes the outer product between column vectors and an **M**x**N** matrix* is accumulated atomically (with device scope) in memory. 
+Computes the outer product between column vectors and an **M**x**N** matrix is
+accumulated component-wise atomically (with device scope) in memory. 
 
 ``` 
 ResultMatrix = InputVector1 * Transpose(InputVector2); 
@@ -270,8 +271,8 @@ declare void @dx.op.vecreducesumacc.v[NUM][TY](
 
 #### Overview
 
-Accumulates the components of a vector atomically (with device scope) to the
-corresponding elements of an array in memory.
+Accumulates the components of a vector component-wise atomically (with device
+scope) to the corresponding elements of an array in memory.
 
 #### Arguments
 
@@ -331,6 +332,8 @@ implementation. A list of combinations that are guaranteed to be supported on
 all implementations can be found in [Minimum Support Set]. Note that there is no
 guaranteed support for **matrix tranpose**, and so it must always queried. s
 queried.
+
+#### Conversation Rules
 
 Non-"Packed" type interpretations are used to request arithmetic conversions. Input type must be a 32-bit or 16-bit
 scalar integer or a 32-bit or 16-bit float. Integer to integer conversion saturates, float to float conversion is


### PR DESCRIPTION
This change makes the cooperative vector proposal focused on specifying the DXIL operations required to support cooperative vectors across a broad range of hardware architectures.

A future proposal will discuss the HLSL API without holding up acceptance of the DXIL operations.

This change also fixes some formatting and layout markdown issues.
