### PR TITLE
[0029] Use "SignedOpKind" enum to indict input/ouput vector signedness

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -133,6 +133,7 @@ specification we add four operations:
 declare <[NUMo] x [TYo] @dx.op.matvecmul.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32        ; opcode
     <[NUMi] x [TYi]>, ; input vector
+    immarg i1,        ; input signed op kind
     immarg i32,       ; input interpretation
     %dx.types.Handle, ; matrix resource
     i32,              ; matrix offset
@@ -142,12 +143,13 @@ declare <[NUMo] x [TYo] @dx.op.matvecmul.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32,       ; matrix layout
     immarg i1,        ; matrix transpose
     i32,              ; matrix stride
-    immarg i1)        ; isResultSigned        <<< See #399
+    immarg i1)        ; output signed op kind
 
 declare <[NUMo] x [TYo]> @dx.op.matvecmuladd.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32        ; opcode
     <[NUMi] x [TYi]>, ; input vector
     immarg i32,       ; input interpretation
+    immarg i1,        ; input signed op kind
     %dx.types.Handle, ; matrix resource
     i32,              ; matrix offset
     immarg i32,       ; matrix interpretation
@@ -159,7 +161,7 @@ declare <[NUMo] x [TYo]> @dx.op.matvecmuladd.v[NUMo][TYo].v[NUMi][TYi](
     %dx.types.Handle, ; bias vector resource
     i32,              ; bias vector offset
     immarg i32,       ; bias vector interpretation
-    immarg i1)        ; isResultSigned        <<< See #399
+    immarg i1)        ; output signed op kind
 ```
 
 #### Overview
@@ -192,6 +194,10 @@ Non-packed interpretations are standard types such as float16, uint etc.  Packed
 types are types such as **SignedInt8x4Packed** where each 32-bit element of the
 vector corresponds to four 8-bit signed integers. See [Type Interpretations]
 for details.
+
+The **input signed op kind** is a value from the existing `SignedOpKind` enum.
+`0` indicates that the input vector is a float or signed integer, `1` indicates
+that the input vector is an unsigned integer.
 
 
 ##### Matrix
@@ -238,6 +244,11 @@ the vector load is out of bounds then the entire operation is undefined.
 This operation returns a vector of size `NUMo` and contains elements of type
 `TYo`. The result vector does not have an interpretation parameter, its type is
 the declared type.
+
+The **output signed op kind** is a value from the existing `SignedOpKind` enum.
+`0` indicates that the output vector is a float or signed integer, `1` indicates
+that the input vector is an unsigned integer.
+
 
 
 ### Vector Outer Product
@@ -403,6 +414,7 @@ Packed Case:
      OPCODE,
      %inputVector,
      8,               ; input interpretation - SignedInt8x4Packed
+     0,               ; input signed op kind = 0 = signed
      %matrixResource,
      0,               ; matrix offset
      5,               ; matrix interpretation - SignedInt8
@@ -411,7 +423,7 @@ Packed Case:
      2,               ; matrix layout - InferencingOptimal
      0,               ; matrix transpose - false
      0,               ; matrix stride
-     1);              ; isResultSigned - true
+     0);              ; output signed op kind = 0 = signed
 ```
 
 Non-Packed Case:
@@ -425,6 +437,7 @@ Non-Packed Case:
     OPCODE,
     %inputVector,
     5,               ; input interpretation - SignedInt8
+    0,               ; input signed op kind = 0 = signed
     %matrixResource,
     0,               ; matrix offset
     5,               ; matrix interpretation - SignedInt8
@@ -433,7 +446,7 @@ Non-Packed Case:
     2,               ; matrix layout - InferencingOptimal
     0,               ; matrix transpose - false
     0,               ; matrix stride
-    1)               ; isResultSigned - true
+    0)               ; output signed op kind = 0 = signed
 ```
 
 #### Precision Requirements


### PR DESCRIPTION
This is an attempt to resolve #399 and #413 in a way that's consistent with existing DXIL opcodes.

* use the existing `SignedOpKind` enum to determine signedness.  Main difference that this inverts the current meaning of this argument, but it brings it inline with other DXIL operations where `0` means float/signed and `1` means unsigned.
* add a new argument for specifying the input vector signedness.

This deliberately doesn't add a general-purpose flags argument. Rationale:
* YAGNI
* if we want to add new flags we should define a new operation that accepts the new flags so the list of accepted flags can be determine just be looking at the opcode


Resolves #413 
Resolves #399
Resolves #414