### PR TITLE
Add stride alignment, FP8 details, fix VectorMatrix to MatrixVector...

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -713,7 +713,7 @@ the inputs required to calculate the necessary size. The same descriptor,
 updated with the calculated output size, is then passed to the conversion
 API. 
 
-The `DestStride` should be a multiple of 16 bytes.
+The `DestStride` must be a multiple of 16 bytes.
 
 ```c++
 


### PR DESCRIPTION
Covers Feedback:
FP8 Emulation Path
Agreement to make explicit in the spec that FP8 matrices must be in optimal layout, which gives the opportunity to store data in FP16. `DONE`
Agreement that the driver and compiler just need to have the same logic for which stride to use, which will be implicit for optimal layouts.
Agreement: spec will only require FP16 internal precision `Internal precision is an implementation detail not covered in spec`
Agreement that the conversion to FP8 optimal layout will be done precisely (exact expected value) `Implementation detail not covered in spec`

Stride
Agreement to add an alignment requirement for stride (multiple of 16) to the spec. `DONE`

Split from : https://github.com/microsoft/hlsl-specs/pull/420.
ReduceSumAccumulate renaming will be handled in a separate PR.