### PR TITLE
[0031] Preliminary Draft of the HLSL changes for CoopVec

### DIFF
--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -228,7 +228,18 @@ void VectorAccumulate(vector<T, N> inputVector, RWByteAddressBuffer Buffer, uint
 
 #### Arguments
 
+
+### Type Interpretation
+
+> To be filled
+
+### Matrix Layout
+
+> To be filled
+
 First strawman:
+
+> To be fixed
 
 ```c++ ByteAddressBuffer inputMatrix0; ByteAddressBuffer inputMatrix1;
 ByteAddressBuffer biasVector0; ByteAddressBuffer biasVector1;
@@ -274,6 +285,6 @@ TBD
 
 ## Acknowledgments (Optional)
 
-TBD
+We would like to thank Jeff Bolz for his contribution to this spec.
 
 <!-- {% endraw %} -->

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -5,8 +5,8 @@
 ## Instructions
 
 - Proposal: [0031](0031-hlsl-vector-matrix-operations.md)
-- Author(s): [Damyan Pepper][damyanp], [Chris Bieneman][llvm-beanz], 
-             [Anupama Chandrasekhar][anupamachandra]
+- Author(s): [Damyan Pepper][damyanp], [Chris Bieneman][llvm-beanz],
+  [Anupama Chandrasekhar][anupamachandra]
 - Sponsor: [Damyan Pepper][damyanp]
 - Status: **Under Consideration**
 - Planned Version: Shader Model 6.9
@@ -18,72 +18,61 @@
 ## Introduction
 
 This proposes a set of HLSL APIs that enable the use of the hardware-accelerated
-vector/matrix operations described in [0029].
+vector/matrix operations described in [0029]. 
 
 [0029]: 0029-cooperative-vector.md
 
 ## Motivation
 
-See [0029] for general background around the need for these new operations.
-
-An HLSL API needs to be defined to expose these new operations in a way that:
-* work well with existing HLSL APIs
-* is expected to work well with future HLSL APIs in the same problem space
-* can be implemented reasonably in DXC and cleanly in clang
-
-This design builds on the "long vectors" feature described in [0026].
+Modern GPUs have dedicated silicon to accelerate matrix operations, but HLSL doesn't provide a mechanism to easily utilize these units. Evaluation of matrix-vector operations (multiply, muladd, accumulation) in HLSL was previously scalarized at the DXIL level making it hard to employ these specialized units. This proposal builds on the "Long vectors" feature described in [0026], providing a mechanism to express matrix-vector ops in HLSL that can be lowered to the DXIL ops described [0029], these primitives provide the right level of abstraction for hardware acceleration.
 
 [0026]: 0026-hlsl-long-vector-type.md
 
 ## Proposed solution
 
+We add the following types and APIs in the dx::linalg (Linear Algebra) namespace: 
+
+
+
+
 First strawman:
 
-```c++
-ByteAddressBuffer inputMatrix0; 
-ByteAddressBuffer inputMatrix1; 
-ByteAddressBuffer biasVector0; 
-ByteAddressBuffer biasVector1;
+```c++ ByteAddressBuffer inputMatrix0; ByteAddressBuffer inputMatrix1;
+ByteAddressBuffer biasVector0; ByteAddressBuffer biasVector1;
 
-void ps_main(args) // args: texture, normal, position
-{   
-    PreProcessing(args);
-    // Neural Network computes the output vector
-    // using the same input args and trained data
-    // in the form of matrices and bias vectors.
+void ps_main(args) // args: texture, normal, position{   PreProcessing(args);
+    // Neural Network computes the output vector using the same input args and
+    // trained data in the form of matrices and bias vectors.
 
     // The input vector is computed from the shader input
     vector<uint32_t, M> inputVector = SomeFunction(args);
 
-    // Below the physical calculations are replaced by NN evaluation
-    // the Matrix and Bias are trained offline and loaded to memory.
+    // Below the physical calculations are replaced by NN evaluation the Matrix
+    // and Bias are trained offline and loaded to memory.
 
-    // layer0 = inputVector*inputMatrix + biasVector0
-    // The matrix and bias are loaded from memory at offsets : moffset0 and boffset0
+    // layer0 = inputVector*inputMatrix + biasVector0 The matrix and bias are
+    // loaded from memory at offsets : moffset0 and boffset0
 
     dx::linalg::MatrixRef inMat0 = {inputMatrix0, moffset0};
-    dx::linalg::VectorRef biasV0 = {biasVector0, boffset0};
-    vector<uint32_t, K> layer0 = dx::linalg::MulAdd(inputVector, inMat0, biasV0);
-    layer0 = max(layer0,0); // Apply activation function
+    dx::linalg::VectorRef biasV0 = {biasVector0, boffset0}; vector<uint32_t, K>
+    layer0 = dx::linalg::MulAdd(inputVector, inMat0, biasV0); layer0 = max
+    (layer0,0); // Apply activation function
 
-    // layer0 = inputVector*inputMatrix0 + biasVector0
-    // The matrix and bias are loaded from memory at offsets : moffset1 and boffset1
+    // layer0 = inputVector*inputMatrix0 + biasVector0 The matrix and bias are
+    // loaded from memory at offsets : moffset1 and boffset1
 
     dx::linalg::MatrixRef inMat1 = {inputMatrix1, moffset1};
-    dx::linalg::VectorRef biasV1 = {biasVector1, boffset1};
-    vector<uint32_t, K> layer1 = dx::linalg::MulAdd(layer0, inMat1, biasV1);
-    layer1 = max(layer1,0); // Apply activation function
+    dx::linalg::VectorRef biasV1 = {biasVector1, boffset1}; vector<uint32_t, K>
+    layer1 = dx::linalg::MulAdd(layer0, inMat1, biasV1); layer1 = max
+    (layer1,0); // Apply activation function
 
     // output = layer1*inputMatrix1 + biasVector1 
     vector<uint32_t, N> output = dx::linalg::MulAdd(layer1, inMat1, biasV1);
 
     output = exp(output); 
 
-    color.r = output[0] * args.lightcolor; 
-    color.g = output[1] * args.lightcolor; 
-    color.b = output[2] * args.lightcolor; 
-}
-```
+    color.r = output[0] * args.lightcolor; color.g = output
+    [1] * args.lightcolor; color.b = output[2] * args.lightcolor; } ```
 
 ## Detailed design
 

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -32,6 +32,32 @@ Modern GPUs have dedicated silicon to accelerate matrix operations, but HLSL doe
 
 We add the following types and APIs in the dx::linalg (Linear Algebra) namespace: 
 
+`dx.linalg.MatrixRef`
+
+`MatrixRef` is a wrapper class around a Matrix stored in a (RW)ByteAddressBuffer that also contains its type, dimension, layout, start offset and stride.
+
+```c++
+namespace dx {
+namespace linalg
+
+template<TypeInterpretation interpretation, uint M, uint K, MatrixLayout layout>
+class MatrixRef {
+    RWByteAddressBuffer Buffer;
+    uint Stride;
+    uint StartOffset;
+}
+
+template<TypeInterpretation interpretation>
+class VectorRef {
+    RWByteAddressBuffer Buffer;
+    uint StartOffset;
+}
+
+}
+}
+
+```
+
 
 
 

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -186,15 +186,20 @@ an bias vector (loaded from memory) to the result.
 #### Syntax
 
 ```c++ 
-namespace dx { 
+namespace dx {
 namespace linalg {
 
-template <TypeInterpretation matrixInterpretation, uint M, uint K, MatrixLayout
-layout, typename InputType, uint InputNumcomp, TypeInterpretation
-InputInterpretation, typename ResultType, bool MatrixNeedsTranspose>
-vector<ResultType, M> Mul(MatrixRef<matrixInterpretation, M, N, layout>
-WeightMatrix, InterpretedVector<InputType, InputNumComp, InputInterpretation>
-InputVector); } }
+template <TypeInterpretation matrixInterpretation, uint M, uint K,
+          MatrixLayout layout, typename InputType, uint InputNumcomp,
+          TypeInterpretation InputInterpretation, typename ResultType,
+          bool MatrixNeedsTranspose>
+vector<ResultType, M>
+Mul(MatrixRef<matrixInterpretation, M, N, layout> WeightMatrix,
+    InterpretedVector<InputType, InputNumComp, InputInterpretation>
+        InputVector);
+
+} // namespace linalg
+} // namespace dx
 
 ```
 

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -255,15 +255,15 @@ void OuterProductAccumulate(vector<T, M> inputVector1,
 #### Syntax
 
 ```c++ 
-namespace dx { 
+namespace dx {
 namespace linalg {
 
-template <typename T, uint N> 
-void VectorAccumulate(vector<T, N> inputVector,
-        RWByteAddressBuffer Buffer, uint StartOffset);
+template <typename T, uint N>
+void VectorAccumulate(vector<T, N> inputVector, RWByteAddressBuffer Buffer,
+                      uint StartOffset);
 
-} 
-} 
+} // namespace linalg
+} // namespace dx
 ```
 
 #### Arguments

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -204,18 +204,20 @@ Mul(MatrixRef<matrixInterpretation, M, N, layout> WeightMatrix,
 ```
 
 ```c++ 
-namespace dx { 
+namespace dx {
 namespace linalg {
 
-template <TypeInterpretation matrixInterpretation, uint M, uint K, MatrixLayout
-layout, TypeInterpretation biasVectorInterpretation, typename InputType, uint
-InputNumcomp, TypeInterpretation InputInterpretation, typename ResultType>
-vector<ResultType, M> MulAdd(MatrixRef<matrixInterpretation, M, N,
-layout> WeightMatrix, InterpretedVector<InputType, InputNumComp,
-InputInterpretation> InputVector, VectorRef<BiasInterpretation> BiasVector);
+template <TypeInterpretation matrixInterpretation, uint M, uint K,
+          MatrixLayout layout, TypeInterpretation biasVectorInterpretation,
+          typename InputType, uint InputNumcomp,
+          TypeInterpretation InputInterpretation, typename ResultType>
+vector<ResultType, M> MulAdd(
+    MatrixRef<matrixInterpretation, M, N, layout> WeightMatrix,
+    InterpretedVector<InputType, InputNumComp, InputInterpretation> InputVector,
+    VectorRef<BiasInterpretation> BiasVector);
 
-} 
-} 
+} // namespace linalg
+} // namespace dx
 ```
 
 #### Arguments

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -61,15 +61,19 @@ offset and stride.
 #### Syntax
 
 ```c++ 
-namespace dx { 
-namespace linalg
+namespace dx {
+namespace linalg {
 
-template<TypeInterpretation Interpretation, uint M, uint K, MatrixLayout Layout>
-class MatrixRef { 
-    RWByteAddressBuffer Buffer; uint Stride; uint StartOffset; }
+template <TypeInterpretation Interpretation, uint M, uint K,
+          MatrixLayout Layout>
+class MatrixRef {
+  RWByteAddressBuffer Buffer;
+  uint Stride;
+  uint StartOffset;
+}
 
-} 
-} 
+} // namespace linalg
+} // namespace dx
 ```
 
 > Note we need to support RWByteAddressBuffer and ByteAddressBuffer if we want

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -235,16 +235,16 @@ vector<ResultType, M> MulAdd(
 #### Syntax
 
 ```c++ 
-namespace dx { 
+namespace dx {
 namespace linalg {
 
-template <typename T, uint M, uint N, MatrixLayout layout, TypeInterpretation
-interpretation> 
+template <typename T, uint M, uint N, MatrixLayout layout,
+          TypeInterpretation interpretation>
 void OuterProductAccumulate(vector<T, M> inputVector1,
-        vector<T, N> inputVector2, MatrixRef<interpretation, M, N, layout>
-        AccMatrix); 
-} 
-}
+                            vector<T, N> inputVector2,
+                            MatrixRef<interpretation, M, N, layout> AccMatrix);
+} // namespace linalg
+} // namespace dx
 
 ```
 

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -144,15 +144,16 @@ The base address of **Buffer** and the **StartOffset** must be 64 byte aligned.
 that vector will be interpreted as.
 
 ```c++ 
-namespace dx { 
+namespace dx {
 namespace linalg {
 
-template<typename T, uint N, TypeInterpretation Interpretation> 
-    class InterpretedVector { 
-        vector<T, N> vec; }
+template <typename T, uint N, TypeInterpretation Interpretation>
+class InterpretedVector {
+  vector<T, N> vec;
+}
 
-} 
-} 
+} // namespace linalg
+} // namespace dx
 ```
 
 #### Arguments

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -110,15 +110,16 @@ ByteAddressBuffer specfying its type and StartOffset.
 >TODO: Needs a length/size parameter?
 
 ```c++ 
-namespace dx { 
+namespace dx {
 namespace linalg {
 
-template<TypeInterpretation Interpretation> 
-    class VectorRef { 
-        RWByteAddressBuffer Buffer; uint StartOffset; }
-
-} 
+template <TypeInterpretation Interpretation> class VectorRef {
+  RWByteAddressBuffer Buffer;
+  uint StartOffset;
 }
+
+} // namespace linalg
+} // namespace dx
 
 ```
 


### PR DESCRIPTION
This draft adds the various HLSL fuctions and classes in the `dx.linalg` space needed for the cooperative vector feature. This PR is a first draft with all these functions defined, not all the details are filled out.