### PR TITLE
2025-03-18 Design Meeting Agenda & Minutes

### DIFF
--- a/docs/DesignMeetingMinutes/2025-03-18.md
+++ b/docs/DesignMeetingMinutes/2025-03-18.md
@@ -40,6 +40,8 @@
 
 ### Current Business
 
+* [Update on 202x & 202y](https://github.com/microsoft/hlsl-specs/pull/391)
+  * Request for reviews
 * [Introduce really rough linalg matrix proposal](https://github.com/microsoft/hlsl-specs/pull/404)
   * Request for reviews
 * [Rough proposal collecting thoughts on uniformity](https://github.com/microsoft/hlsl-specs/pull/405)

--- a/docs/DesignMeetingMinutes/2025-03-18.md
+++ b/docs/DesignMeetingMinutes/2025-03-18.md
@@ -1,0 +1,75 @@
+# Design Meeting Minutes: 2025/03/18
+
+> NOTE: Please read the [terms of participation](DesignMeetingTerms.txt)
+> ("Terms") prior to joining the Teams meeting.  You joining the Teams meeting
+> with Microsoft indicates your acknowledgement, agreement, and consent to these
+> Terms.  If you do not agree to these Terms, please do not join the meeting.
+>
+> If you intend to contribute code or other copyrightable materials (e.g.
+> written comments, tools, documentation, etc.)  to the hlsl specs repository,
+> you are required to sign a Contributor License Agreement (CLA).  For details,
+> visit https://cla.microsoft.com.
+
+## Administrivia
+* FYI: Updaters coming to design meeting terms
+
+## Issues
+* No marked issues
+* Action Item: @llvm-beanz to review issues for HLSL 202x
+
+## PRs
+
+### Carried Forward
+
+* [[0007] Big update to flesh out const instance methods](https://github.com/microsoft/hlsl-specs/pull/34)
+  * Action Item: @pow2clk to review the PR and comment
+* [[0002] Specify the grammar formulations for attributes](https://github.com/microsoft/hlsl-specs/pull/65)
+  * @llvm-beanz provided update, needs review.
+* [[dxil] Proposal to add new debug printf dxil op](https://github.com/microsoft/hlsl-specs/pull/324)
+  * @pow2clk and @tex3d will review this in more detail.
+* [[202x] Propose adding vk::SampledTexture* types](https://github.com/microsoft/hlsl-specs/pull/343)
+  * Ready to merge.
+* [Specification language to describe flat conversions and aggregate splats](https://github.com/microsoft/hlsl-specs/pull/358)
+  * @llvm-beanz provided feedback, need second review.
+  * Action Item: @spall to update
+* [Add proposal for scalar layout for constant buffers](https://github.com/microsoft/hlsl-specs/pull/317)
+  * Action Item @llvm-beanz - Move to merge.
+* [Adding proposal for C++ constructors](https://github.com/microsoft/hlsl-specs/pull/325)
+  * Carried forward - Action Item: @V-FEXrt to review.
+  * Action Item @llvm-beanz - Move to merge.
+
+### Current Business
+
+* [Introduce really rough linalg matrix proposal](https://github.com/microsoft/hlsl-specs/pull/404)
+  * Request for reviews
+* [Rough proposal collecting thoughts on uniformity](https://github.com/microsoft/hlsl-specs/pull/405)
+  * Request for reviews
+* [Constant buffers language spec - initial draft](https://github.com/microsoft/hlsl-specs/pull/419)
+  * Action Item: @llvm-beanz to review
+
+### SM 6.9
+
+* [Long vector test plan](https://github.com/microsoft/hlsl-specs/pull/421)
+* [Cooperative Vectors Test Plan](https://github.com/microsoft/hlsl-specs/pull/428)
+* [[0029] Use consistent n-byte aligned notation](https://github.com/microsoft/hlsl-specs/pull/429)
+  * Action Item: @damyanp to merge
+* [[0029] Clarify 16-byte underling allocation requirement](https://github.com/microsoft/hlsl-specs/pull/430)
+  * Neds second review
+* [[0031] Preliminary draft of the HLSL changes for CoopVec](https://github.com/microsoft/hlsl-specs/pull/432)
+  * Action Item: @llvm-beanz to review
+* [[0029] Fix some stale type names / typos in Coop Vec D3D API example](https://github.com/microsoft/hlsl-specs/pull/434)
+  * Action Item: @damyanp to review
+
+
+## Other Discussion
+
+* [Report on impact of overload resolution behavior](https://github.com/microsoft/hlsl-specs/pull/408)
+* [202x](https://github.com/microsoft/hlsl-specs/milestone/2)
+  * [Deprecate and remove `interface` keyword](https://github.com/microsoft/hlsl-specs/issues/291)
+  * [Deprecate existing `uniform` keyword usage ](https://github.com/microsoft/hlsl-specs/issues/135)
+  * [Remove unsized arrays](https://github.com/microsoft/hlsl-specs/issues/141)
+  * [Error on cbuffer variable initializer](https://github.com/microsoft/hlsl-specs/issues/259)
+  * [static variable inside cbuffer are not marked const](https://github.com/microsoft/hlsl-specs/issues/351)
+    * @hekota can you review this?
+  * [Remove HLSL Effects Syntax
+    Support](https://github.com/microsoft/hlsl-specs/issues/380)

--- a/docs/DesignMeetingMinutes/2025-03-18.md
+++ b/docs/DesignMeetingMinutes/2025-03-18.md
@@ -11,11 +11,10 @@
 > visit https://cla.microsoft.com.
 
 ## Administrivia
-* FYI: Updaters coming to design meeting terms
+* FYI: Updates coming to design meeting terms
 
 ## Issues
 * No marked issues
-* Action Item: @llvm-beanz to review issues for HLSL 202x
 
 ## PRs
 
@@ -23,8 +22,10 @@
 
 * [[0007] Big update to flesh out const instance methods](https://github.com/microsoft/hlsl-specs/pull/34)
   * Action Item: @pow2clk to review the PR and comment
+  * Action Item: @V-FEXrt & @spall to review
 * [[0002] Specify the grammar formulations for attributes](https://github.com/microsoft/hlsl-specs/pull/65)
   * @llvm-beanz provided update, needs review.
+  * Action Item: @V-FEXrt to review.
 * [[dxil] Proposal to add new debug printf dxil op](https://github.com/microsoft/hlsl-specs/pull/324)
   * @pow2clk and @tex3d will review this in more detail.
 * [[202x] Propose adding vk::SampledTexture* types](https://github.com/microsoft/hlsl-specs/pull/343)
@@ -32,6 +33,7 @@
 * [Specification language to describe flat conversions and aggregate splats](https://github.com/microsoft/hlsl-specs/pull/358)
   * @llvm-beanz provided feedback, need second review.
   * Action Item: @spall to update
+  * Action Item: @V-FEXrt to review.
 * [Add proposal for scalar layout for constant buffers](https://github.com/microsoft/hlsl-specs/pull/317)
   * Action Item @llvm-beanz - Move to merge.
 * [Adding proposal for C++ constructors](https://github.com/microsoft/hlsl-specs/pull/325)
@@ -48,6 +50,7 @@
   * Request for reviews
 * [Constant buffers language spec - initial draft](https://github.com/microsoft/hlsl-specs/pull/419)
   * Action Item: @llvm-beanz to review
+  * Action Item: @V-FEXrt to review.
 
 ### SM 6.9
 
@@ -72,6 +75,6 @@
   * [Remove unsized arrays](https://github.com/microsoft/hlsl-specs/issues/141)
   * [Error on cbuffer variable initializer](https://github.com/microsoft/hlsl-specs/issues/259)
   * [static variable inside cbuffer are not marked const](https://github.com/microsoft/hlsl-specs/issues/351)
-    * @hekota can you review this?
+    * Action Item: @V-FEXrt to review.
   * [Remove HLSL Effects Syntax
     Support](https://github.com/microsoft/hlsl-specs/issues/380)


### PR DESCRIPTION
This PR adds the stub meeting minutes as an agened for the 3/18/2025 design meeting.