### PR TITLE
[0029] Alternative way to query D3D device for supported CoopVec type combinations (no HLSL/DXIL impact)

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -734,6 +734,10 @@ still reported out via the `ConfigurationSupported` field mentioned above
 > that might become interesting.  Then the D3D caps check just confirms
 > the interesting new config is available as expected on the device/driver.
 
+> If `TransposeSupported` is false and the configuration is in the minimum
+> supported set, D3D will answer the support query without asking the driver,
+> so the driver only needs to report configurations beyond the baseline.
+
 >Note about emulation: For example E4M3 and E5M2 might not be supported natively
  on certain implementations, but since these are in the minimum support set,
  they need to be emulated, possibly using FP16. Emulation versus native support


### PR DESCRIPTION
This proposes changing the way cooperative vector type combinations are reported from the driver from a list of all combinations to instead the app individually requesting whether the driver supports a given configuration defined by the app.

No HLSL/DXIL impact here, just a tweak to the D3D API.   Question for reviewers:  Does this make sense?  Note the commentary included in the changed spec text discussing how an app would use this new paradigm.