### PR TITLE
[0029] Fix ComponentType numbering comments

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -391,8 +391,8 @@ enum class ComponentType : uint32_t {
   U32, // = 5
   I64,
   U64,
-  F16, // = 7
-  F32, // = 8
+  F16, // = 8
+  F32, // = 9
   F64,
   SNormF16,
   UNormF16,
@@ -400,14 +400,14 @@ enum class ComponentType : uint32_t {
   UNormF32,
   SNormF64,
   UNormF64,
-  PackedS8x32, // = 16
-  PackedU8x32, // = 17
+  PackedS8x32, // = 17
+  PackedU8x32, // = 18
 
   // BEGIN NEW FOR SM 6.9
-  U8,      // = 18
-  I8,      // = 19
-  F8_E4M3, // = 20  
-  F8_E5M2, // = 21
+  U8,      // = 19
+  I8,      // = 20
+  F8_E4M3, // = 21  
+  F8_E5M2, // = 22
   // END     
 
   LastEntry

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -645,14 +645,14 @@ typedef enum D3D12_LINEAR_ALGEBRA_DATATYPE {
   D3D12_LINEAR_ALGEBRA_DATATYPE_UINT16          =  3, // ComponentType::U16
   D3D12_LINEAR_ALGEBRA_DATATYPE_SINT32          =  4, // ComponentType::I32
   D3D12_LINEAR_ALGEBRA_DATATYPE_UINT32          =  5, // ComponentType::U32
-  D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16         =  7, // ComponentType::F16
-  D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32         =  8, // ComponentType::F32
-  D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8_T4_PACKED = 16, // ComponentType::PackedS8x32
-  D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8_T4_PACKED = 17, // ComponentType::PackedU8x32
-  D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8           = 18, // ComponentType::U8
-  D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8           = 19, // ComponentType::I8
-  D3D12_LINEAR_ALGEBRA_DATATYPE_E4M3            = 20, // ComponentType::F8_E4M3 (1 sign, 4 exp, 3 mantissa bits)
-  D3D12_LINEAR_ALGEBRA_DATATYPE_E5M2            = 21, // ComponentType::F8_E5M2 (1 sign, 5 exp, 2 mantissa bits)
+  D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16         =  8, // ComponentType::F16
+  D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32         =  9, // ComponentType::F32
+  D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8_T4_PACKED = 17, // ComponentType::PackedS8x32
+  D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8_T4_PACKED = 18, // ComponentType::PackedU8x32
+  D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8           = 19, // ComponentType::U8
+  D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8           = 20, // ComponentType::I8
+  D3D12_LINEAR_ALGEBRA_DATATYPE_E4M3            = 21, // ComponentType::F8_E4M3 (1 sign, 4 exp, 3 mantissa bits)
+  D3D12_LINEAR_ALGEBRA_DATATYPE_E5M2            = 22, // ComponentType::F8_E5M2 (1 sign, 5 exp, 2 mantissa bits)
 };
 
 typedef enum D3D12_COOPERATIVE_VECTOR_TIER


### PR DESCRIPTION
I noticed that these comments weren't lining up with what Intellisense was telling me the actual values were.