### PR TITLE
[0029] Define commandList interactions for LinearAlgebraConvertMatrix() [no HLSL/DXIL impact]

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -940,7 +940,8 @@ void ID3D12CommandList::ConvertLinearAlgebraMatrix(D3D12_LINEAR_ALGEBRA_MATRIX_C
      - Dest access: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
      - Sync point: D3D12_BARRIER_SYNC_CONVERT_LINEAR_ALGEBRA_MATRIX
  - Predication is supported
- - Not available in Bundles
+ - Avaiable in Compute or Graphics CommandLists
+ - Not supported in Bundles
 
 *Usage Example:*
 

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -932,13 +932,13 @@ void ID3D12CommandList::ConvertLinearAlgebraMatrix(D3D12_LINEAR_ALGEBRA_MATRIX_C
 
 - Synchronization around `ConvertLinearAlgebraMatrix` calls:
    - Legacy Barrier
-     - Source buffer: Must be in D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE state
-     - Dest buffer: Must be in D3D12_RESOURCE_STATE_UNORDERED_ACCESS state
+     - Source buffer: Must be in `D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE` state
+     - Dest buffer: Must be in `D3D12_RESOURCE_STATE_UNORDERED_ACCESS` state
      - UAV barrier synchronizes writes to the destination
    - Enhanced Barrier:
-     - Source buffer access: D3D12_BARRIER_ACCESS_SHADER_RESOURCE
-     - Dest buffer access: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
-     - Sync point: D3D12_BARRIER_SYNC_CONVERT_LINEAR_ALGEBRA_MATRIX
+     - Source buffer access: `D3D12_BARRIER_ACCESS_SHADER_RESOURCE`
+     - Dest buffer access: `D3D12_BARRIER_ACCESS_UNORDERED_ACCESS`
+     - Sync point: `D3D12_BARRIER_SYNC_CONVERT_LINEAR_ALGEBRA_MATRIX`
  - Predication is supported
  - Avaiable in Compute or Graphics CommandLists
  - Not supported in Bundles

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -932,12 +932,12 @@ void ID3D12CommandList::ConvertLinearAlgebraMatrix(D3D12_LINEAR_ALGEBRA_MATRIX_C
 
 - Synchronization around `ConvertLinearAlgebraMatrix` calls:
    - Legacy Barrier
-     - Source: Must be in D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE state
-     - Dest: Must be in D3D12_RESOURCE_STATE_UNORDERED_ACCESS state
+     - Source buffer: Must be in D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE state
+     - Dest buffer: Must be in D3D12_RESOURCE_STATE_UNORDERED_ACCESS state
      - UAV barrier synchronizes writes to the destination
    - Enhanced Barrier:
-     - Source access: D3D12_BARRIER_ACCESS_SHADER_RESOURCE
-     - Dest access: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+     - Source buffer access: D3D12_BARRIER_ACCESS_SHADER_RESOURCE
+     - Dest buffer access: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
      - Sync point: D3D12_BARRIER_SYNC_CONVERT_LINEAR_ALGEBRA_MATRIX
  - Predication is supported
  - Avaiable in Compute or Graphics CommandLists

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -932,8 +932,8 @@ void ID3D12CommandList::ConvertLinearAlgebraMatrix(D3D12_LINEAR_ALGEBRA_MATRIX_C
 
 - Synchronization around `ConvertLinearAlgebraMatrix` calls:
    - Legacy Barrier
-     - Source state: D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
-     - Dest state: D3D12_RESOURCE_STATE_UNORDERED_ACCESS
+     - Source: Must be in D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE state
+     - Dest: Must be in D3D12_RESOURCE_STATE_UNORDERED_ACCESS state
      - UAV barrier synchronizes writes to the destination
    - Enhanced Barrier:
      - Source access: D3D12_BARRIER_ACCESS_SHADER_RESOURCE

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -940,7 +940,7 @@ void ID3D12CommandList::ConvertLinearAlgebraMatrix(D3D12_LINEAR_ALGEBRA_MATRIX_C
      - Dest buffer access: `D3D12_BARRIER_ACCESS_UNORDERED_ACCESS`
      - Sync point: `D3D12_BARRIER_SYNC_CONVERT_LINEAR_ALGEBRA_MATRIX`
  - Predication is supported
- - Avaiable in Compute or Graphics CommandLists
+ - Available in Compute or Graphics CommandLists
  - Not supported in Bundles
 
 *Usage Example:*

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -928,6 +928,19 @@ void ID3D12CommandList::ConvertLinearAlgebraMatrix(D3D12_LINEAR_ALGEBRA_MATRIX_C
 * If SrcComponentType and DestComponentType are not equal, then one should be `D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32`  or `D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16` and the other should be a lower-precision floating-point type. 
 * If DestComponentType is `D3D12_LINEAR_ALGEBRA_DATATYPE_E4M3` or `D3D12_LINEAR_ALGEBRA_DATATYPE_E5M2`, then DestLayout should be `D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_INFERENCING_OPTIMAL` or `D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_TRAINING_OPTIMAL`.
 
+*CommandList interactions:*
+
+- Synchronization around `ConvertLinearAlgebraMatrix` calls:
+   - Legacy Barrier
+     - Source state: D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
+     - Dest state: D3D12_RESOURCE_STATE_UNORDERED_ACCESS
+     - UAV barrier synchronizes writes to the destination
+   - Enhanced Barrier:
+     - Source access: D3D12_BARRIER_ACCESS_SHADER_RESOURCE
+     - Dest access: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+     - Sync point: D3D12_BARRIER_SYNC_LINEAR_ALGEBRA_CONVERT_MATRIX
+ - Predication is supported
+ - Not available in Bundles
 
 *Usage Example:*
 

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -938,7 +938,7 @@ void ID3D12CommandList::ConvertLinearAlgebraMatrix(D3D12_LINEAR_ALGEBRA_MATRIX_C
    - Enhanced Barrier:
      - Source access: D3D12_BARRIER_ACCESS_SHADER_RESOURCE
      - Dest access: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
-     - Sync point: D3D12_BARRIER_SYNC_LINEAR_ALGEBRA_CONVERT_MATRIX
+     - Sync point: D3D12_BARRIER_SYNC_CONVERT_LINEAR_ALGEBRA_MATRIX
  - Predication is supported
  - Not available in Bundles
 


### PR DESCRIPTION
LinearAlgebraConvertMatrix() is a D3D commandList method.  This change outlines interactions with command list infrastructure, in particular interaction with barriers.