### PR TITLE
[0031] Add builtins

### DIFF
--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -174,23 +174,26 @@ namespace details {
 
 // dx.op.matvecmul
 template <typename TYo, int NUMo, typename TYi, int NUMi, typename RES>
-void __builtin_MatVecMul(vector<TYi, NUMi> InputVector,
-                         uint InputVectorInterpretation, RES MatrixResource,
-                         uint MatrixStartOffset, uint MatrixInterpretation,
-                         uint M, uint K, uint Layout, bool MatrixTranspose,
-                         uint MatrixStride, out vector<TYo, NUMo> OutputVector);
+void __builtin_MatVecMul(out vector<TYo, NUMo> OutputVector,
+                         bool IsOutputUnsigned, vector<TYi, NUMi> InputVector,
+                         bool IsInputUnsigned, uint InputVectorInterpretation,
+                         RES MatrixResource, uint MatrixStartOffset,
+                         uint MatrixInterpretation, uint M, uint K,
+                         uint MatrixLayout, bool MatrixTranspose,
+                         uint MatrixStride);
 
 // dx.op.matvecmuladd
 template <typename TYo, int NUMo, typename TYi, int NUMi, typename RESm,
           typename RESv>
-void __builtin_MatVecMulAdd(vector<TYi, NUMi> InputVector,
+void __builtin_MatVecMulAdd(out vector<TYo, NUMo> OutputVector,
+                            bool IsOutputUnsigned,
+                            vector<TYi, NUMi> InputVector, bool IsInputUnsigned,
                             uint InputVectorInterpretation, RESm MatrixResource,
                             uint MatrixStartOffset, uint MatrixInterpretation,
-                            uint M, uint K, uint Layout, bool MatrixTranspose,
-                            uint MatrixStride, RESv BiasVectorResource,
-                            uint BiasVectorOffset,
-                            uint BiasVectorInterpretation,
-                            out vector<TYo, NUMo> OutputVector);
+                            uint M, uint K, uint MatrixLayout,
+                            bool MatrixTranspose, uint MatrixStride,
+                            RESv BiasVectorResource, uint BiasVectorOffset,
+                            uint BiasVectorInterpretation);
 
 // dx.op.outerproductaccumulate
 template <typename TY, int M, int N, typename RES>

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -173,11 +173,11 @@ namespace linalg {
 namespace details {
 
 // dx.op.matvecmul
-template <typename TYo, int NUMo, typename TYi, int NUMi, typename RES>
+template <typename TYo, int NUMo, typename TYi, int NUMi, typename RESm>
 void __builtin_MatVecMul(out vector<TYo, NUMo> OutputVector,
                          bool IsOutputUnsigned, vector<TYi, NUMi> InputVector,
                          bool IsInputUnsigned, uint InputVectorInterpretation,
-                         RES MatrixResource, uint MatrixStartOffset,
+                         RESm MatrixResource, uint MatrixStartOffset,
                          uint MatrixInterpretation, uint M, uint K,
                          uint MatrixLayout, bool IsMatrixTransposed,
                          uint MatrixStride);

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -160,7 +160,54 @@ TBD
 
 ### Builtins
 
-TBD
+Although these "builtins" are not intended to be part of the HLSL language, and
+no promises are made that these will continue to be available over time, this
+proposal describes an implementation in terms of builtins such as this. For
+this reason it is useful to have them described here as a reference point.
+
+Each builtin corresponds to one of the operations described in [0029].
+
+```c++
+namespace dx {
+namespace linalg {
+namespace details {
+
+// dx.op.matvecmul
+template <typename TYo, int NUMo, typename TYi, int NUMi, typename RES>
+vector<TYo, NUMo>
+__builtin_Mul(vector<TYi, NUMi> InputVector, uint InputVectorInterpretation,
+              RES MatrixResource, uint MatrixStartOffset,
+              uint MatrixInterpretation, uint M, uint K, uint Layout,
+              bool MatrixTranspose, uint MatrixStride);
+
+// dx.op.matvecmuladd
+template <typename TYo, int NUMo, typename TYi, int NUMi, typename RESm,
+          typename RESv>
+vector<TYo, NUMo>
+__builtin_MulAdd(vector<TYi, NUMi> InputVector, uint InputVectorInterpretation,
+                 RESm MatrixResource, uint MatrixStartOffset,
+                 uint MatrixInterpretation, uint M, uint K, uint Layout,
+                 bool MatrixTranspose, uint MatrixStride,
+                 RESv BiasVectorResource, uint BiasVectorOffset,
+                 uint BiasVectorInterpretation);
+
+// dx.op.outerproductaccumulate
+template <typename TY, int M, int N, typename RES>
+void __builtin_OuterProductAccumulate(
+    vector<TY, M> InputVector1, vector<TY, N> InputVector2, RES MatrixResource,
+    uint MatrixStartOffset, DataType MatrixInterpretation, MatrixLayout Layout);
+
+// dx.op.vectoraccumulate
+template <typename TY, int NUM, typename RES>
+void __builtin_VectorAccumulate(vector<TY, NUM> InputVector,
+                                RES OutputArrayResource,
+                                uint OutputArrayOffset);
+
+} // namespace details
+} // namespace linalg
+} // namespace dx
+
+```
 
 ## Alternatives considered (Optional)
 

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -179,7 +179,7 @@ void __builtin_MatVecMul(out vector<TYo, NUMo> OutputVector,
                          bool IsInputUnsigned, uint InputVectorInterpretation,
                          RES MatrixResource, uint MatrixStartOffset,
                          uint MatrixInterpretation, uint M, uint K,
-                         uint MatrixLayout, bool MatrixTranspose,
+                         uint MatrixLayout, bool IsMatrixTransposed,
                          uint MatrixStride);
 
 // dx.op.matvecmuladd
@@ -191,7 +191,7 @@ void __builtin_MatVecMulAdd(out vector<TYo, NUMo> OutputVector,
                             uint InputVectorInterpretation, RESm MatrixResource,
                             uint MatrixStartOffset, uint MatrixInterpretation,
                             uint M, uint K, uint MatrixLayout,
-                            bool MatrixTranspose, uint MatrixStride,
+                            bool IsMatrixTransposed, uint MatrixStride,
                             RESv BiasVectorResource, uint BiasVectorOffset,
                             uint BiasVectorInterpretation);
 

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -174,22 +174,23 @@ namespace details {
 
 // dx.op.matvecmul
 template <typename TYo, int NUMo, typename TYi, int NUMi, typename RES>
-void __builtin_Mul(vector<TYi, NUMi> InputVector,
-                   uint InputVectorInterpretation, RES MatrixResource,
-                   uint MatrixStartOffset, uint MatrixInterpretation, uint M,
-                   uint K, uint Layout, bool MatrixTranspose, uint MatrixStride,
-                   out vector<TYo, NUMo> OutputVector);
+void __builtin_MatVecMul(vector<TYi, NUMi> InputVector,
+                         uint InputVectorInterpretation, RES MatrixResource,
+                         uint MatrixStartOffset, uint MatrixInterpretation,
+                         uint M, uint K, uint Layout, bool MatrixTranspose,
+                         uint MatrixStride, out vector<TYo, NUMo> OutputVector);
 
 // dx.op.matvecmuladd
 template <typename TYo, int NUMo, typename TYi, int NUMi, typename RESm,
           typename RESv>
-void __builtin_MulAdd(vector<TYi, NUMi> InputVector,
-                      uint InputVectorInterpretation, RESm MatrixResource,
-                      uint MatrixStartOffset, uint MatrixInterpretation, uint M,
-                      uint K, uint Layout, bool MatrixTranspose,
-                      uint MatrixStride, RESv BiasVectorResource,
-                      uint BiasVectorOffset, uint BiasVectorInterpretation,
-                      out vector<TYo, NUMo> OutputVector);
+void __builtin_MatVecMulAdd(vector<TYi, NUMi> InputVector,
+                            uint InputVectorInterpretation, RESm MatrixResource,
+                            uint MatrixStartOffset, uint MatrixInterpretation,
+                            uint M, uint K, uint Layout, bool MatrixTranspose,
+                            uint MatrixStride, RESv BiasVectorResource,
+                            uint BiasVectorOffset,
+                            uint BiasVectorInterpretation,
+                            out vector<TYo, NUMo> OutputVector);
 
 // dx.op.outerproductaccumulate
 template <typename TY, int M, int N, typename RES>

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -174,22 +174,22 @@ namespace details {
 
 // dx.op.matvecmul
 template <typename TYo, int NUMo, typename TYi, int NUMi, typename RES>
-vector<TYo, NUMo>
-__builtin_Mul(vector<TYi, NUMi> InputVector, uint InputVectorInterpretation,
-              RES MatrixResource, uint MatrixStartOffset,
-              uint MatrixInterpretation, uint M, uint K, uint Layout,
-              bool MatrixTranspose, uint MatrixStride);
+void __builtin_Mul(vector<TYi, NUMi> InputVector,
+                   uint InputVectorInterpretation, RES MatrixResource,
+                   uint MatrixStartOffset, uint MatrixInterpretation, uint M,
+                   uint K, uint Layout, bool MatrixTranspose, uint MatrixStride,
+                   out vector<TYo, NUMo> OutputVector);
 
 // dx.op.matvecmuladd
 template <typename TYo, int NUMo, typename TYi, int NUMi, typename RESm,
           typename RESv>
-vector<TYo, NUMo>
-__builtin_MulAdd(vector<TYi, NUMi> InputVector, uint InputVectorInterpretation,
-                 RESm MatrixResource, uint MatrixStartOffset,
-                 uint MatrixInterpretation, uint M, uint K, uint Layout,
-                 bool MatrixTranspose, uint MatrixStride,
-                 RESv BiasVectorResource, uint BiasVectorOffset,
-                 uint BiasVectorInterpretation);
+void __builtin_MulAdd(vector<TYi, NUMi> InputVector,
+                      uint InputVectorInterpretation, RESm MatrixResource,
+                      uint MatrixStartOffset, uint MatrixInterpretation, uint M,
+                      uint K, uint Layout, bool MatrixTranspose,
+                      uint MatrixStride, RESv BiasVectorResource,
+                      uint BiasVectorOffset, uint BiasVectorInterpretation,
+                      out vector<TYo, NUMo> OutputVector);
 
 // dx.op.outerproductaccumulate
 template <typename TY, int M, int N, typename RES>

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -194,9 +194,12 @@ void __builtin_MatVecMulAdd(vector<TYi, NUMi> InputVector,
 
 // dx.op.outerproductaccumulate
 template <typename TY, int M, int N, typename RES>
-void __builtin_OuterProductAccumulate(
-    vector<TY, M> InputVector1, vector<TY, N> InputVector2, RES MatrixResource,
-    uint MatrixStartOffset, DataType MatrixInterpretation, MatrixLayout Layout);
+void __builtin_OuterProductAccumulate(vector<TY, M> InputVector1,
+                                      vector<TY, N> InputVector2,
+                                      RES MatrixResource,
+                                      uint MatrixStartOffset,
+                                      DataType MatrixInterpretation,
+                                      MatrixLayout Layout, uint MatrixStride);
 
 // dx.op.vectoraccumulate
 template <typename TY, int NUM, typename RES>

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -201,8 +201,8 @@ void __builtin_OuterProductAccumulate(vector<TY, M> InputVector1,
                                       vector<TY, N> InputVector2,
                                       RES MatrixResource,
                                       uint MatrixStartOffset,
-                                      DataType MatrixInterpretation,
-                                      MatrixLayout Layout, uint MatrixStride);
+                                      uint MatrixInterpretation,
+                                      uint Layout, uint MatrixStride);
 
 // dx.op.vectoraccumulate
 template <typename TY, int NUM, typename RES>


### PR DESCRIPTION
Although these "builtins" are not intended to be part of the HLSL language, and
no promises are made that these will continue to be available over time, this
proposal describes an implementation in terms of builtins such as this. For
this reason it is useful to have them described here as a reference point.

Each builtin corresponds to one of the operations described in [0029].

[0029]: 0029-cooperative-vector.md


----

For this review, I'm keen on feedback for whether or not this is a good way to describe the builtins?  At the moment they're HLSL code that I know can compile, but that might mean they've picked up HLSL-isms that don't necessarily apply to a specification of a builtin.
