### PR TITLE
[0029] Fix description of OuterProductAccumulate

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -301,7 +301,7 @@ Computes the outer product between column vectors and an **M**x**N** matrix is
 accumulated component-wise atomically (with device scope) in memory. 
 
 ``` 
-ResultMatrix = InputVector1 * Transpose(InputVector2); 
+ResultMatrix += InputVector1 * Transpose(InputVector2); 
 ```
 
 


### PR DESCRIPTION
It should be `+=`, not `+`.