### PR TITLE
Add PR description checker to hlsl-specs

### DIFF
--- a/.github/workflows/pr-description-checker.yml
+++ b/.github/workflows/pr-description-checker.yml
@@ -1,0 +1,18 @@
+name: 'PR description checker'
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - labeled
+      - unlabeled
+jobs:
+  check-pr-description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jadrol/pr-description-checker-action@c659fed338a52d657d34462c8bc7fc1f65d25758
+        id: description-checker
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a github action to verify that PR descriptions are not empty. We have this on DXC to enforce our policy and should have it here as well.