### PR TITLE
[0029] Fix sample code tier check

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -777,7 +777,7 @@ D3D12_FEATURE_DATA_D3D12_OPTIONSNN TierSupport = {};
 d3d12Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONSNN, &TierSupport, 
                                  sizeof(D3D12_FEATURE_DATA_D3D12_OPTIONSNN));
 
-if (TierSupport.CooperativeVectorTier == D3D12_COOPERATIVE_VECTOR_TIER_1_0) {
+if (TierSupport.CooperativeVectorTier >= D3D12_COOPERATIVE_VECTOR_TIER_1_0) {
     // PropCounts to be filled by driver implementation
     D3D12_FEATURE_DATA_COOPERATIVE_VECTOR CoopVecProperties = {0, NULL, 0, NULL, 0, NULL};
 


### PR DESCRIPTION
Tier checks should use >=, otherwise the feature will suddenly be disabled when new functionality arrives. Sample code should get this right so people copying it into their own apps get the right behavior by default.