### PR TITLE
[0029] Make "input signed op kind"s be "is input unsigned" and booleans

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -149,7 +149,7 @@ specification we add four operations:
 declare <[NUMo] x [TYo]> @dx.op.matvecmul.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32        ; opcode
     <[NUMi] x [TYi]>, ; input vector
-    immarg i1,        ; input signed op kind
+    immarg i1,        ; is input unsigned
     immarg i32,       ; input interpretation
     %dx.types.Handle, ; matrix resource
     i32,              ; matrix offset
@@ -159,12 +159,12 @@ declare <[NUMo] x [TYo]> @dx.op.matvecmul.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32,       ; matrix layout
     immarg i1,        ; matrix transpose
     i32,              ; matrix stride
-    immarg i1)        ; output signed op kind
+    immarg i1)        ; is output unsigned
 
 declare <[NUMo] x [TYo]> @dx.op.matvecmuladd.v[NUMo][TYo].v[NUMi][TYi](
     immarg i32        ; opcode
     <[NUMi] x [TYi]>, ; input vector
-    immarg i1,        ; input signed op kind
+    immarg i1,        ; is input unsigned
     immarg i32,       ; input interpretation
     %dx.types.Handle, ; matrix resource
     i32,              ; matrix offset
@@ -177,7 +177,7 @@ declare <[NUMo] x [TYo]> @dx.op.matvecmuladd.v[NUMo][TYo].v[NUMi][TYi](
     %dx.types.Handle, ; bias vector resource
     i32,              ; bias vector offset
     immarg i32,       ; bias vector interpretation
-    immarg i1)        ; output signed op kind
+    immarg i1)        ; is output unsigned
 ```
 
 #### Overview
@@ -211,9 +211,9 @@ types are types such as **SignedInt8x4Packed** where each 32-bit element of the
 vector corresponds to four 8-bit signed integers. See [Type Interpretations]
 for details.
 
-The **input signed op kind** is a value from the existing `SignedOpKind` enum.
-`0` indicates that the input vector is a float or signed integer, `1` indicates
-that the input vector is an unsigned integer.
+The **is input unsigned** is a boolean value; `false` indicates that the input
+vector is a float or signed integer, `true` indicates that the input vector is
+an unsigned integer.
 
 
 ##### Matrix
@@ -263,9 +263,9 @@ This operation returns a vector of size `NUMo` and contains elements of type
 `TYo`. The result vector does not have an interpretation parameter, its type is
 the declared type.
 
-The **output signed op kind** is a value from the existing `SignedOpKind` enum.
-`0` indicates that the output vector is a float or signed integer, `1` indicates
-that the input vector is an unsigned integer.
+The **is output unsigned** is a boolean value; `false` indicates that the input
+vector is a float or signed integer, `true` indicates that the input vector is
+an unsigned integer.
 
 #### Validation
 
@@ -519,7 +519,7 @@ Packed Case:
      OPCODE,
      %inputVector,
      16,              ; input interpretation - ComponentType::PackedS8x32
-     0,               ; input signed op kind = 0 = signed
+     false,           ; is input unsigned = false = signed
      %matrixResource,
      0,               ; matrix offset
      19,              ; matrix interpretation - ComponentType::I8
@@ -528,7 +528,7 @@ Packed Case:
      2,               ; matrix layout - MulOptimal
      0,               ; matrix transpose - false
      0,               ; matrix stride
-     0);              ; output signed op kind = 0 = signed
+     0);              ; is output unsigned = false = signed
 ```
 
 Non-Packed Case:
@@ -542,7 +542,7 @@ Non-Packed Case:
     OPCODE,
     %inputVector,
     19,              ; input interpretation - ComponentType::I8
-    0,               ; input signed op kind = 0 = signed
+    0,               ; is input unsigned = false = signed
     %matrixResource,
     0,               ; matrix offset
     5,               ; matrix interpretation - ComponentType::I8
@@ -551,7 +551,7 @@ Non-Packed Case:
     2,               ; matrix layout - MulOptimal
     0,               ; matrix transpose - false
     0,               ; matrix stride
-    0)               ; output signed op kind = 0 = signed
+    0)               ; is output unsigned = false = signed
 ```
 
 #### Precision Requirements


### PR DESCRIPTION
This doesn't change the specified behavior of these parameters, but is easier to follow since `i1`s are printed as `true` and `false` and, while implementing the feature, it made more sense to use simple booleans.