### PR TITLE
Add an initial proposal for HLSL 202x deprecations

### DIFF
--- a/proposals/0036-202x-deprecations.md
+++ b/proposals/0036-202x-deprecations.md
@@ -2,7 +2,7 @@
 
 # 202x Feature Deprecations
 
-* Proposal: [NNNN](NNNN-202x-deprecations.md)
+* Proposal: [0036](0036-202x-deprecations.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: TBD
 * Status: **Under Consideration**


### PR DESCRIPTION
This proposal seeks to enumerate the smaller features that should be deprecated or significantly tightened in HLSL 202x, which are not large enough to indipendently warrant their own proposal documents.

These features represent technical debt in DXC's implementation of HLSL which should be removed in future language versions to avoid carrying it forward indefinitely.