### PR TITLE
Design meeting minutes for 2025-06-10

### DIFF
--- a/docs/DesignMeetingMinutes/2025-06-10.md
+++ b/docs/DesignMeetingMinutes/2025-06-10.md
@@ -46,6 +46,7 @@
 * [Cooperative Vectors Test Plan](https://github.com/microsoft/hlsl-specs/pull/428)
 * [[0029] Minor typos in 0029-cooperative-vector.md](https://github.com/microsoft/hlsl-specs/pull/503)
 * **New** [[0029][0031]In linalg Mul/MulAdd functions, the memory backing the Matrix and Bias buffers must be read-only](https://github.com/microsoft/hlsl-specs/pull/507)
+  * Action Item: @pow2clk to review
 * **New** [[Shader Execution Reordering] Minor spec inconsistency: HitObject::MakeMiss missing Ray in argument listing](https://github.com/microsoft/hlsl-specs/pull/512)
 
 ## Other Discussion


### PR DESCRIPTION
This adds the design meeting minutes for the 2025/06/10 meeting.