### PR TITLE
[0007] Adding spec language for const instance methods

### DIFF
--- a/proposals/0007-const-member-functions.md
+++ b/proposals/0007-const-member-functions.md
@@ -148,11 +148,58 @@ RWBuffer<T>` via copy-initialization (standard copy construction), allowing
 `setValueConst` to call `setValue`. This does not violate const-correctness
 since the handle is treated as const while the data it references is not.
 
-### Detailed Description of Overload Resolution Rules
+### Language Specification Updates
 
-TBD: HLSL's current overload resolution rules are not fully codified anywhere
-I'm aware of. For this design to be complete we need to fully specify the
-overload resolution and standard argument conversions.
+> The HLSL specification chapter on
+> [**Overloading**](https://microsoft.github.io/hlsl-specs/specs/hlsl.html#Overload)
+> specifies the overload resolution behavior for HLSL aligning with C++ behavior.
+> [microsoft/hlsl-specs#408](https://github.com/microsoft/hlsl-specs/pull/408)
+> provides an analysis of the impact of this behavior change on existing HLSL
+> sources.
+
+#### **Overload.Res.Sets**
+
+For a given expression, the set of candidate functions may contain both member
+and non-member functions. Member functions have an additional _implicit object
+parameter_, which represents the object the function is called on. For the
+purposes of overload resolution all member functions (static and non-static) are
+considered to have implicit object parameters; constructors and destructors are
+not.
+
+When appropriate, an _implied object argument_ can be inferred from the context
+in which overload resolution is occurring to denote the object being operated on.
+
+The type of the implicit object parameter for non-static member functions of
+type `T` is lvalue reference to cv-qualified `T`.
+
+For conversion functions that have an implicit object parameter, the type of the
+implicit object parameter will match the type of the implicit object argument in
+the unresolved expression. For non-conversion functions that are included in the
+candidate set by a _using-declaration_ in a derived class, the implicit object
+parameter shall be of the type of the derived class. The implicit object
+parameter of a static member function can match any object.
+
+> Note: Conversion functions and _using-declaration_ surfaced member functions
+> behave as if they are members of derived classes in overload resolution. The
+> wording in the C++ spec is a bit convoluted, but that intent is carried over
+> here.
+
+No user-defined conversion sequences may be implicitly applied to an implicit
+object parameter during overload resolution. In all other regards, the implied
+object argument shall be treated identical to other arguments.
+
+Arguments to the implied object parameter must not be held in temporary objects
+and may not have user-defined conversions applied to match the implicit object
+parameter type. An rvalue may only be converted to an implicit object parameter
+if all other aspects of the type match.
+
+If a candidate function is a function template, template argument deduction
+generates a list of candidate function template specializations, which are then
+handled the same as non-template function candidates. A single name may both
+refer to one or more overloaded non-template functions and one or more function
+templates. The candidate set for an unresolved expression shall combine all
+function overloads and template function specializations to form a complete
+overload set.
 
 ### Other Considerations
 


### PR DESCRIPTION
This adds additional language for how the implicit object parameters are handled during overload resolution. The main key points in this language are:

1) No conversions may be applied to the implicit object parameter.
2) No temporary may be created to hold the implicit object argument.

Point 2 is what restricts binding a temporary to a const implicit object.

Closes #283