### PR TITLE
Proposal housekeeping - updating status, consistent field values

### DIFF
--- a/proposals/0001-hlsl-namespace.md
+++ b/proposals/0001-hlsl-namespace.md
@@ -3,7 +3,7 @@
 * Proposal: [0001](0001-hlsl-namespace.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 
 ## Introduction

--- a/proposals/0002-cxx-attributes.md
+++ b/proposals/0002-cxx-attributes.md
@@ -4,7 +4,7 @@
 * Proposal: [0002](0002-cxx-attributes.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 
 ## Introduction

--- a/proposals/0003-numeric-constants.md
+++ b/proposals/0003-numeric-constants.md
@@ -3,7 +3,7 @@
 * Proposal: [0003](0003-numeric-constants.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202x
 
 ## Introduction

--- a/proposals/0004-unions.md
+++ b/proposals/0004-unions.md
@@ -3,7 +3,7 @@
 * Proposal: [0004](0004-unions.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 
 ## Introduction

--- a/proposals/0005-strict-initializer-lists.md
+++ b/proposals/0005-strict-initializer-lists.md
@@ -5,7 +5,7 @@
 * Proposal: [0005](0005-strict-initializer-lists.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 
 ## Introduction

--- a/proposals/0006-reference-types.md
+++ b/proposals/0006-reference-types.md
@@ -3,7 +3,7 @@
 * Proposal: [0006](0006-reference-types.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 
 ## Introduction

--- a/proposals/0007-const-member-functions.md
+++ b/proposals/0007-const-member-functions.md
@@ -3,8 +3,8 @@
 
 * Proposal: [0007](0007-const-member-functions.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
-* Sponsor: TBD
-* Status: **Under Consideration**
+* Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
+* Status: **Under Review**
 * Planned Version: 202y
 
 ## Introduction

--- a/proposals/0008-non-member-operator-overloading.md
+++ b/proposals/0008-non-member-operator-overloading.md
@@ -1,11 +1,9 @@
 # Non-member Operator Overloading
 
-## Instructions
-
 * Proposal: [0008](0008-non-member-operator-overloading.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 * Related Proposal(s): [0006 Reference Types](0006-reference types.md)
 

--- a/proposals/0009-math-modes.md
+++ b/proposals/0009-math-modes.md
@@ -3,7 +3,7 @@
 * Proposal: [0009](0009-math-modes.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 * Dependencies: [0002 C++ Attributes](0002-cxx-attributes.md)
 

--- a/proposals/0013-wave-size-range.md
+++ b/proposals/0013-wave-size-range.md
@@ -3,8 +3,8 @@
 * Proposal: [0013](0013-wave-size-range.md)
 * Author(s): [Greg Roth](https://github.com/pow2clk)
 * Sponsor: [Greg Roth](https://github.com/pow2clk)
-* Status: Complete
-* Version: Shader Model 6.8
+* Status: Completed
+* Version: SM 6.8
 
 ## Introduction
 

--- a/proposals/0014-expanded-comparison-sampling.md
+++ b/proposals/0014-expanded-comparison-sampling.md
@@ -4,8 +4,8 @@
 * Author(s): [Greg Roth](https://github.com/pow2clk),
              [Jesse Natalie](https://github.com/jenatali)
 * Sponsor: [Greg Roth](https://github.com/pow2clk)
-* Status: Complete
-* Version: Shader Model 6.8
+* Status: Completed
+* Version: SM 6.8
 
 ## Introduction
 

--- a/proposals/0015-extended-command-info.md
+++ b/proposals/0015-extended-command-info.md
@@ -3,8 +3,8 @@
 * Proposal: [0015](0015-extended-command-info.md)
 * Author(s): [Greg Roth](https://github.com/pow2clk)
 * Sponsor: [Greg Roth](https://github.com/pow2clk)
-* Status: Complete
-* Version: Shader Model 6.8
+* Status: Completed
+* Version: SM 6.8
 
 ## Introduction
 

--- a/proposals/0018-work-graphs.md
+++ b/proposals/0018-work-graphs.md
@@ -6,7 +6,7 @@
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz), [Greg Roth](https://github.com/pow2clk)
 * Sponsor: [Greg Roth](https://github.com/pow2clk), [Tex Riddell](https://github.com/tex3d)
 * Status: Completed
-* Version: Shader Model 6.8
+* Version: SM 6.8
 
 ## Introduction
 

--- a/proposals/0018-work-graphs.md
+++ b/proposals/0018-work-graphs.md
@@ -6,7 +6,7 @@
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz), [Greg Roth](https://github.com/pow2clk)
 * Sponsor: [Greg Roth](https://github.com/pow2clk), [Tex Riddell](https://github.com/tex3d)
 * Status: Completed
-* Version: SM 6.8
+* Planned Version: SM 6.8
 
 ## Introduction
 

--- a/proposals/0018-work-graphs.md
+++ b/proposals/0018-work-graphs.md
@@ -3,11 +3,9 @@
 # Work Graphs
 
 * Proposal: [0018](0018-work-graphs.md)
-* Author(s): [Chris Bieneman](https://github.com/llvm-beanz),
-  [Greg Roth](https://github.com/pow2clk)
-* Sponsor: [Greg Roth](https://github.com/pow2clk), [Tex
-  Riddell](https://github.com/tex3d)
-* Status: Complete
+* Author(s): [Chris Bieneman](https://github.com/llvm-beanz), [Greg Roth](https://github.com/pow2clk)
+* Sponsor: [Greg Roth](https://github.com/pow2clk), [Tex Riddell](https://github.com/tex3d)
+* Status: Completed
 * Version: Shader Model 6.8
 
 ## Introduction

--- a/proposals/0019-mesh-nodes.md
+++ b/proposals/0019-mesh-nodes.md
@@ -4,7 +4,7 @@
 * Author(s): [Tex Riddell](https://github.com/tex3d), [Amar Patel](https://github.com/amarpMSFT)
 * Sponsor: [Tex Riddell](https://github.com/tex3d)
 * Status: **Under Consideration**
-* Proposed Version: SM 6.9 experimental
+* Planned Version: SM 6.x
 
 ## Introduction
 

--- a/proposals/0020-hlsl-202x-202y.md
+++ b/proposals/0020-hlsl-202x-202y.md
@@ -5,7 +5,7 @@
 * Proposal: [0020](0020-hlsl-202x-202y.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Impacted Projects: DXC & Clang
 
 ## Introduction

--- a/proposals/0023-cxx11-base.md
+++ b/proposals/0023-cxx11-base.md
@@ -5,7 +5,7 @@
 * Proposal: [0023](0023-cxx11-base.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: TBD
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 
 ## Introduction

--- a/proposals/0024-opacity-micromaps.md
+++ b/proposals/0024-opacity-micromaps.md
@@ -5,7 +5,7 @@
 * Proposal: [0024](0024-opacity-micromaps.md)
 * Author(s): [Tex Riddell](https://github.com/tex3d)
 * Sponsor: [Tex Riddell](https://github.com/tex3d)
-* Status: **Under Review**
+* Status: **Accepted**
 * Planned Version: SM 6.9
 
 > NOTE: some links in this document are to internal documents that are not

--- a/proposals/0024-opacity-micromaps.md
+++ b/proposals/0024-opacity-micromaps.md
@@ -2,21 +2,11 @@
 
 # Opacity Micromaps
 
-## Instructions
-
 * Proposal: [0024](0024-opacity-micromaps.md)
 * Author(s): [Tex Riddell](https://github.com/tex3d)
 * Sponsor: [Tex Riddell](https://github.com/tex3d)
 * Status: **Under Review**
-
-<!--
-*During the review process, add the following fields as needed:*
-
-* Planned Version: Shader Model X.Y
-* PRs: [#NNNN](https://github.com/microsoft/DirectXShaderCompiler/pull/NNNN)
-* Issues:
-  [#NNNN](https://github.com/microsoft/DirectXShaderCompiler/issues/NNNN)
-  -->
+* Planned Version: SM 6.9
 
 > NOTE: some links in this document are to internal documents that are not
 > currently publically available. This file will be updated once they are

--- a/proposals/0025-max-records-per-node.md
+++ b/proposals/0025-max-records-per-node.md
@@ -3,7 +3,8 @@
 * Proposal: [0025](0025-max-records-per-node.md)
 * Author(s): [Anupama Chandrasekhar](https://github.com/anupamachandra), [Mike Apodaca](https://github.com/mapodaca-nv)
 * Sponsor: Damyan Pepper
-* Status: **Under Consideration**
+* Status: **Under Review**
+* Planned Version: SM 6.x
 
 # [MaxRecordsPerNode(count)] Attribute for NodeOutputArray
 

--- a/proposals/0026-hlsl-long-vector-type.md
+++ b/proposals/0026-hlsl-long-vector-type.md
@@ -2,10 +2,11 @@
 
 # HLSL Long Vectors
 
-* Proposal: [0026-HLSL-Vectors](0026-hlsl-vector-type.md)
+* Proposal: [0026](0026-hlsl-vector-type.md)
 * Author(s): [Anupama Chandrasekhar](https://github.com/anupamachandra), [Greg Roth](https://github.com/pow2clk)
-* Sponsor: [Greg Roth](https://github.com/pow2clk)
-* Status: **Under Consideration**
+* Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
+* Status: **Accepted**
+* Planned Version: SM 6.9
 
 ## Introduction
 

--- a/proposals/0027-shader-execution-reordering.md
+++ b/proposals/0027-shader-execution-reordering.md
@@ -5,8 +5,9 @@
 * Author(s): [Rasmus Barringer](https://github.com/rasmusnv), Robert Toth,
 Michael Haidl, Simon Moll, Martin Stich
 * Sponsor: [Tex Riddell](https://github.com/tex3d)
-* Status: **Under Consideration**
+* Status: **Accepted**
 * Impacted Projects: DXC
+* Planned Version: SM 6.9
 
 ## Introduction
 

--- a/proposals/0028-dxil18.md
+++ b/proposals/0028-dxil18.md
@@ -6,7 +6,7 @@
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
 * Status: **Completed**
-* Planned Version: Shader Model 6.8
+* Planned Version: SM 6.8
 
 > Note: this proposal is preserved as documentation for DXIL 1.8. It was
 > implemented as a fast-track extension and shipped in DXC 1.8. This

--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -5,7 +5,7 @@
              [Shashank Wadhwa][shashankw]
 * Sponsor: [Damyan Pepper][damyanp], [Greg Roth][pow2clk]
 * Status: **Under Review**
-* Planned Version: Shader Model 6.9
+* Planned Version: SM 6.9
 
 
 [anupamachandra]: https://github.com/anupamachandra

--- a/proposals/0030-dxil-vectors.md
+++ b/proposals/0030-dxil-vectors.md
@@ -6,9 +6,9 @@
 
 * Proposal: [0030](0030-dxil-vectors.md)
 * Author(s): [Greg Roth](https://github.com/pow2clk)
-* Sponsor: [Greg Roth](https://github.com/pow2clk)
-* Status: **Under Consideration**
-* Planned Version: Shader Model 6.9
+* Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
+* Status: **Accepted**
+* Planned Version: SM 6.9
 
 ## Introduction
 

--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -2,14 +2,12 @@
 
 # HLSL Vector Matrix Operations
 
-## Instructions
-
-- Proposal: [0031](0031-hlsl-vector-matrix-operations.md)
-- Author(s): [Damyan Pepper][damyanp], [Chris Bieneman][llvm-beanz],
+* Proposal: [0031](0031-hlsl-vector-matrix-operations.md)
+* Author(s): [Damyan Pepper][damyanp], [Chris Bieneman][llvm-beanz],
   [Anupama Chandrasekhar][anupamachandra]
-- Sponsor: [Damyan Pepper][damyanp]
-- Status: **Under Consideration**
-- Planned Version: Shader Model 6.9
+* Sponsor: [Damyan Pepper][damyanp]
+* Status: **Under Review**
+* Planned Version: SM 6.9
 
 [damyanp]: https://github.com/damyanp
 [llvm-beanz]: https://github.com/llvm-beanz

--- a/proposals/0032-constructors.md
+++ b/proposals/0032-constructors.md
@@ -3,7 +3,7 @@
 * Proposal: [0032](0032-constructors.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Planned Version: 202y
 
 ## Introduction

--- a/proposals/0033-dxil19.md
+++ b/proposals/0033-dxil19.md
@@ -6,7 +6,7 @@
 * Author(s): [Damyan Pepper](https://github.com/damyanp)
 * Sponsor: [Damyan Pepper](https://github.com/damyanp)
 * Status: **Under Review**
-* Planned Version: Shader Model 6.9
+* Planned Version: SM 6.9
 
 ## Introduction
 

--- a/proposals/0034-vk-sampled-texture.md
+++ b/proposals/0034-vk-sampled-texture.md
@@ -5,7 +5,7 @@
 * Proposal: [0034](0034-vk-sampled-texture.md)
 * Author(s): [Cassandra Beckley](https://github.com/cassiebeckley)
 * Sponsor: [Steven Perron](https://github.com/s-perron) and TBD
-* Status: **Under Consideration**
+* Status: **Under Review**
 * Required Version: HLSL 2021
 <!--
 * PRs: [#NNNN](https://github.com/microsoft/DirectXShaderCompiler/pull/NNNN)

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -5,7 +5,8 @@
 * Proposal: [0035](0035-linalg-matrix.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
 * Sponsor: TBD
-* Status: **Under Consideration**
+* Status: **Under Review**
+* Planned Version: SM 6.x
 
 ## Introduction
 

--- a/proposals/0036-202x-deprecations.md
+++ b/proposals/0036-202x-deprecations.md
@@ -4,8 +4,8 @@
 
 * Proposal: [0036](0036-202x-deprecations.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz)
-* Sponsor: TBD
-* Status: **Under Consideration**
+* Sponsor: [Chris Bieneman](https://github.com/llvm-beanz)
+* Status: **Under Review**
 * Planned Version: 202x
 * Issues: [#300](https://github.com/microsoft/hlsl-specs/issues/380),
   [#291](https://github.com/microsoft/hlsl-specs/issues/291),

--- a/proposals/0037-cbuffer-contexts.md
+++ b/proposals/0037-cbuffer-contexts.md
@@ -2,8 +2,6 @@
 
 # Refined `cbuffer` Contexts
 
-## Instructions
-
 * Proposal: [0037](0037-cbuffer-contexts.md)
 * Author(s): [Chris Bieneman](https://github.com/llvm-beanz), [Helena Kotas](https://github.com/hekota)
 * Sponsor: TBD

--- a/proposals/infra/INF-0005-validator-backcompat-testing.md
+++ b/proposals/infra/INF-0005-validator-backcompat-testing.md
@@ -2,8 +2,6 @@
 
 # Feature name
 
-## Instructions
-
 * Proposal: [INF-0005](INF-0005-validator-backcompat-testing.md)
 * Author(s): [Damyan Pepper](https://github.com/damyanp)
 * Sponsor: [Damyan Pepper](https://github.com/damyanp)


### PR DESCRIPTION
See Process.md for details on the what the proposal states mean.

This change consists of a pass through making editorial changes to be more consistent in field naming (eg "SM 6.9" rather than "Shader Model 6.9") or to fix issues that were throwing off the metadata parser.  In addition, these proposals have changed state:

These proposals have moved to Under Review:
* 0001-hlsl-namespace.md
* 0002-cxx-attributes.md
* 0003-numeric-constants.md
* 0004-unions.md
* 0005-strict-initializer-lists.md
* 0006-reference-types.md
* 0007-const-member-functions.md
* 0008-non-member-operator-overloading.md
* 0009-math-modes.md
* 0020-hlsl-202x-202y.md
* 0023-cxx11-base.md
* 0025-max-records-per-node.md
* 0031-hlsl-vector-matrix-operations.md
* 0032-constructors.md
* 0034-vk-sampled-texture.md
* 0035-linalg-matrix.md
* 0036-202x-deprecations.md

These proposals have move to Accepted:
* 0024-opacity-micromaps.md
* 0026-hlsl-vector-type.md
* 0027-shader-execution-reordering.md
* 0030-dxil-vectors.md

The changes in these proposals are editorial only:
* 0013-wave-size-range.md
* 0014-expanded-comparison-sampling.md
* 0015-extended-command-info.md
* 0018-work-graphs.md
* 0019-mesh-nodes.md
* 0028-dxil18.md
* 0029-cooperative-vector.md
* 0033-dxil19.md
* 0037-cbuffer-contexts.md
* INF-0005-validator-backcompat-testing.md
