### PR TITLE
[0035] `linalg::Matrix` detailed design revision

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -59,18 +59,19 @@ enum class MatrixScope {
 };
 
 enum class UnaryOperation {
-  nop = 0,
-  negate = 1,
-  abs = 2,
-  sin = 3,
-  cos = 4,
-  tan = 5,
-  // What elementwise unary operations make sense?
+  NOp = 0,
+  Negate = 1,
+  Abs = 2,
+  Sin = 3,
+  Cos = 4,
+  Tan = 5,
 };
 
 template <MatrixComponentType ComponentTy, uint M, uint N, MatrixUse Use,
           MatrixScope Scope>
 class Matrix {
+  using ElementType = __detail::ComponentTypeTraits<ComponentTy>::Type;
+
   template <MatrixComponentType NewCompTy, MatrixUse NewUse = Use>
   Matrix<NewCompTy, M, N, NewUse, Scope> cast();
 
@@ -90,51 +91,57 @@ class Matrix {
 
   // Apply a unary operation to each element.
   template<UnaryOperation Op>
-  Matrix unaryOperation();
+  Matrix ApplyUnaryOperation();
 
   template <typename T>
     requires ArithmeticScalar<T>
   static Matrix Splat(T Val);
   static Matrix
   Load(ByteAddressBuffer Res, uint StartOffset, uint Stride, bool ColMajor,
-       uint Align = sizeof(__detail::ComponentTyMapping<ComponentTy>::Type));
+       uint Align = sizeof(ElementType));
   static Matrix
   Load(RWByteAddressBuffer Res, uint StartOffset, uint Stride, bool ColMajor,
-       uint Align = sizeof(__detail::ComponentTyMapping<ComponentTy>::Type));
+       uint Align = sizeof(ElementType));
 
   template <typename T>
     requires ArithmeticScalar<T>
-  static Matrix Load(/*groupshared*/ T Arr[], uint StartIdx, uint Stride,
+  static Matrix Load(groupshared T Arr[], uint StartIdx, uint Stride,
                      bool ColMajor);
 
   void
   Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride, bool ColMajor,
-        uint Align = sizeof(__detail::ComponentTyMapping<ComponentTy>::Type));
+        uint Align = sizeof(ElementType));
 
   template <typename T>
     requires ArithmeticScalar<T>
-  void Store(/*groupshared*/ T Arr[], uint StartIdx, uint Stride,
+  void Store(groupshared T Arr[], uint StartIdx, uint Stride,
              bool ColMajor);
 
   // Row accesses
-  vector<ComponentTy, M> GetRow(uint Index);
-  void SetRow(vector<ComponentTy, M> V, uint Index);
+  vector<ElementType, M> GetRow(uint Index);
+  void SetRow(vector<ElementType, M> V, uint Index);
 
   // Element access
-  ComponentTy Get(uint2 Index);
-  void Set(ComponentTy V, uint2 Index);
+  std::enable_if_t<__detail::ComponentTypeTraits<ComponentTy>::IsNativeScalar,
+                   ElementType>
+  Get(uint2 Index);
+  std::enable_if_t<__detail::ComponentTypeTraits<ComponentTy>::IsNativeScalar,
+                   void>
+  Set(ElementType V, uint2 Index);
 
-  template <typename T>
+  template <typename T, uint K>
     requires ArithmeticScalar<T>
-  std::enable_if_t<Use == MatrixUse::Accumulator, void>
-  MultiplyAccumulate(const Matrix<T, N, M, MatrixUse::A, Scope> &,
-                     const Matrix<T, N, M, MatrixUse::B, Scope> &);
+  std::enable_if_t<Use == MatrixUse::Accumulator && Scope == MatrixScope::Wave,
+                   void>
+  MultiplyAccumulate(const Matrix<T, M, K, MatrixUse::A, Scope> &,
+                     const Matrix<T, K, N, MatrixUse::B, Scope> &);
 
-  template <typename T>
+  template <typename T, unit K>
     requires ArithmeticScalar<T>
-  std::enable_if_t<Use == MatrixUse::Accumulator, void>
-  SumAccumulate(const Matrix<T, N, M, MatrixUse::A, Scope> &,
-                const Matrix<T, N, M, MatrixUse::B, Scope> &);
+  std::enable_if_t<Use == MatrixUse::Accumulator && Scope == MatrixScope::Wave,
+                   void>
+  SumAccumulate(const Matrix<T, M, K, MatrixUse::A, Scope>,
+                const Matrix<T, K, N, MatrixUse::B, Scope>);
 
   // Cooperative Vector outer product accumulate.
   template <typename T>
@@ -142,10 +149,10 @@ class Matrix {
   OuterProductAccumulate(const vector<T, M> &, const vector<T, N> &);
 };
 
-template <typename T, uint M, uint N, uint K, MatrixScope Scope>
-Matrix<T, M, N, MatrixUse::A, Scope>
-Multiply(const Matrix<T, M, K, MatrixUse::A, Scope>,
-         const Matrix<T, K, N, MatrixUse::B, Scope>);
+template <typename T, uint M, uint N, uint K>
+Matrix<T, M, N, MatrixUse::A, MatrixScope::Wave>
+Multiply(const Matrix<T, M, K, MatrixUse::A, MatrixScope::Wave>,
+         const Matrix<T, K, N, MatrixUse::B, MatrixScope::Wave>);
 
 // Cooperative Vector Replacement API
 // Cooperative Vector operates on per-thread vectors multiplying against B
@@ -160,16 +167,416 @@ Multiply(vector<InputElTy, M> InputVector,
 template <typename OutputElTy, typename InputElTy, typename BiasElTy, uint M,
           uint K, MatrixComponentType MatrixDT, MatrixScope Scope,
           bool MatrixTranspose>
-vector<OutputElTy, M>
-MultiplyAdd(vector<InputElTy, K> InputVector,
+vector<OutputElTy, K>
+MultiplyAdd(vector<InputElTy, M> InputVector,
             Matrix<MatrixDT, M, K, MatrixUse::B, Scope> Matrix,
-            vector<BiasElTy, M> BiasVector);
+            vector<BiasElTy, K> BiasVector);
 
 } // namespace linalg
 } // namespace hlsl
 ```
 
 ## Detailed design
+
+### HLSL API Concepts
+
+The new HLSL API introduces a new `linalg::Matrix` type which represents an
+opaque matrix object, and contains an intangible handle that refers to the
+allocated matrix.
+
+The `linalg::Matrix` template type is parameterized based on the matrix
+component data type, dimensions, use, and scope. These parameters restrict where
+and how a matrix can be used.
+
+#### Matrix Use
+
+The `Use` parameter of an instance of a `linalg::Matrix` denotes which argument
+it can be in matrix-matrix operations or matrix-vector operations.
+
+There are three matrix usages: `A`, `B`, and `Accumulator`.
+* The `A` matrix usage denotes a matrix that can be the first argument to binary
+  or ternary algebraic operations.
+* The `B` matrix usage denotes a matrix that can the second argument to binary
+  or ternary algebraic operations.
+* The `Accumulator` matrix usage denotes a matrix that can either be a produced
+  result from a binary arithmetic operation, or the third argument to a ternary
+  algebraic operation.
+
+#### Matrix Scope
+
+The `Scope` parameter of an instance of a `linalg::Matrix` denotes the
+uniformity scope of the matrix. The scope impacts which operations can be
+performed on the matrix and may have performance implications depending on the
+implementation.
+
+There are two supported matrix scopes: `Thread` and `Wave`.
+* The `Thread` matrix scope denotes that a matrix's values may vary by thread,
+  which requires that an implementation handle divergent matrix values.
+* The `Wave` matrix scope denotes that a matrix's values are uniform across a
+  wave, which allows an implementation to assume all instances of the matrix
+  across a wave are identical.
+
+Some operations require `Wave` scope matrices, while others can operate on
+`Thread` scope matrices. All operations that can operate on `Thread` scope
+matrices can also operate on `Wave` scope matrices, and there may be significant
+performance benefit when using `Wave` scope matrices.
+
+### HLSL API Documentation
+
+#### HLSL Enumerations
+```c++
+enum class MatrixComponentType {
+  Invalid = 0,
+  I1 = 1,
+  I16 = 2,
+  U16 = 3,
+  I32 = 4,
+  U32 = 5,
+  I64 = 6,
+  U64 = 7,
+  F16 = 8,
+  F32 = 9,
+  F64 = 10,
+  SNormF16 = 11,
+  UNormF16 = 12,
+  SNormF32 = 13,
+  UNormF32 = 14,
+  SNormF64 = 15,
+  UNormF64 = 16,
+  PackedS8x32 = 17,
+  PackedU8x32 = 18,
+};
+
+enum class MatrixUse {
+  A = 0,
+  B = 1,
+  Accumulator = 2,
+};
+
+enum class MatrixScope {
+  Thread = 0,
+  Wave = 1,
+};
+
+enum class UnaryOperation {
+  NOp = 0,
+  Negate = 1,
+  Abs = 2,
+  Sin = 3,
+  Cos = 4,
+  Tan = 5,
+};
+
+```
+
+#### Helper type traits
+
+```c++
+namespace __detail {
+template<MatrixComponentType T>
+struct ComponentTypeTraits {
+    using Type = uint;
+    static const bool IsNativeScalar = false;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::I16> {
+    using Type = int16_t;
+    static const bool IsNativeScalar = true;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::U16> {
+    using Type = uint16_t;
+    static const bool IsNativeScalar = true;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::I32> {
+    using Type = int32_t;
+    static const bool IsNativeScalar = true;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::U32> {
+    using Type = uint32_t;
+    static const bool IsNativeScalar = true;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::I64> {
+    using Type = int64_t;
+    static const bool IsNativeScalar = true;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::U64> {
+    using Type = uint64_t;
+    static const bool IsNativeScalar = true;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::F16> {
+    using Type = float16_t;
+    static const bool IsNativeScalar = true;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::F32> {
+    using Type = float;
+    static const bool IsNativeScalar = true;
+};
+
+template<>
+struct ComponentTypeTraits<MatrixComponentType::F64> {
+    using Type = double;
+    static const bool IsNativeScalar = true;
+};
+} // namespace __detail
+```
+
+The `linalg::__detail::ComponentTypeTraits` struct is provided as an
+implementation detail to enable mapping `MatrixComponentType` values to their
+native HLSL element types and differentiating between types that have native
+scalar support.
+
+#### Matrix::cast
+
+```c++
+template <MatrixComponentType NewCompTy, MatrixUse NewUse = Use>
+Matrix<NewCompTy, M, N, NewUse, Scope> Matrix::cast();
+```
+
+The `Matrix::cast()` function supports casting component types and matrix `Use`.
+
+#### Element-wise Operators
+
+```c++
+template <typename T>
+  requires ArithmeticScalar<T>
+Matrix Matrix::operator+(T);
+template <typename T>
+  requires ArithmeticScalar<T>
+Matrix Matrix::operator-(T);
+template <typename T>
+  requires ArithmeticScalar<T>
+Matrix Matrix::operator*(T);
+template <typename T>
+  requires ArithmeticScalar<T>
+Matrix Matrix::operator/(T);
+```
+
+For any arithmetic scalar type the `+`, `-`, `*` and `/` binary operators
+perform element-wise arithmetic on the matrix. The returned by-value `Matrix`
+contains the same handle and refers to the same (now modified) `Matrix`.
+
+#### Matrix::ApplyUnaryOperation<>()
+
+```c++
+template<linalg::UnaryOperation Op>
+Matrix Matrix::ApplyUnaryOperation();
+```
+
+Taking the `linalg::UnaryOperation` enumeration value as a template parameter,
+this function applies a unary operation to each element in the matrix. Each
+unary operation will behave with regard to special values in the same way as if
+the standalone HLSL intrinsic had been applied.
+
+#### Matrix::Splat(T)
+
+
+```c++
+template <typename T>
+  requires ArithmeticScalar<T>
+static Matrix Matrix::Splat(T Val);
+```
+
+Constructs a matrix filled with the provided value casted to the element type.
+If the matrix is a `Wave` scope matrix, this operation shall behave equivalent
+to:
+
+```c++
+Matrix::Splat(WaveReadLaneFirst(Val));
+```
+
+#### Matrix::Load
+
+```c++
+static Matrix Matrix::Load(
+    ByteAddressBuffer Res, uint StartOffset, uint Stride, bool ColMajor,
+    uint Align = sizeof(__detail::ComponentTypeTraits<ComponentTy>::Type));
+
+static Matrix Matrix::Load(
+    RWByteAddressBuffer Res, uint StartOffset, uint Stride, bool ColMajor,
+    uint Align = sizeof(__detail::ComponentTypeTraits<ComponentTy>::Type));
+
+template <typename T>
+  requires ArithmeticScalar<T>
+static Matrix Matrix::Load(groupshared T Arr[], uint StartIdx, uint Stride,
+                           bool ColMajor);
+```
+
+The matrix `Load` methods create a new matrix of the specified dimensions and
+fill the matrix by reading data from the supplied source. Matrices can be read
+from `[RW]ByteAddressBuffer` objects or `groupshared` arrays. When read from
+`[RW]ByteAddressBuffer` objects the data is assumed to already be in the
+expected target data format. When read from `groupshared` memory, the data may
+be in any arithmetic or packed data type. If the type mismatches the target data
+type of the matrix a data conversion is applied on load.
+
+
+#### Matrix::Store
+
+```c++
+void Matrix::Store(
+    RWByteAddressBuffer Res, uint StartOffset, uint Stride, bool ColMajor,
+    uint Align = sizeof(__detail::ComponentTypeTraits<ComponentTy>::Type));
+
+template <typename T>
+  requires ArithmeticScalar<T>
+void Matrix::Store(groupshared T Arr[], uint StartIdx, uint Stride,
+                   bool ColMajor);
+```
+
+The matrix `Store` methods store the matrix data to a target
+`RWByteAddressBuffer` or `groupshared` array. When storing to
+`RWByteAddressBuffer` objects the data is stored in the component type of the
+matrix object. When storing to `groupshared` memory, the matrix component data
+is converted to the target arithmetic or packed data type if the data types do
+not match.
+
+#### Matrix::GetRow(uint)
+
+```c++
+vector<ElementType, M> Matrix::GetRow(uint Index);
+```
+
+Returns a row vector of the matrix as a vector of the underlying HLSL native
+element type. If `Index` is out of range for the matrix size the result is a `0`
+filled vector.
+
+
+#### Matrix::SetRow(vector<ElementType, M>, uint)
+
+```c++
+void Matrix::SetRow(vector<ElementType, M> V, uint Index);
+```
+
+Sets the specified matrix row to the value in the vector V. If the matrix scope
+is `Wave`, this behaves as if called as `SetRow(WaveReadLaneFirst(V), Index)`.
+If the `Index` is out of range of the matrix, this is a no-op.
+
+#### Matrix::Get(uint2)
+
+```c++
+std::enable_if_t<__detail::ComponentTypeTraits<ComponentTy>::IsNativeScalar,
+                 ElementType>
+Matrix::Get(uint2 Index);
+```
+
+Accesses a specific component of the matrix using two-dimensional indexing. This
+method is only available if the component type has has native scalar support in
+HLSL. If the `Index` parameter is out-of range for the matrix the result is `0`
+casted to `ElementType`.
+
+#### Matrix::Set(ElementType, uint2)
+
+```c++
+std::enable_if_t<__detail::ComponentTypeTraits<ComponentTy>::IsNativeScalar,
+                 void>
+Matrix::Set(ElementType V, uint2 Index);
+```
+
+Sets a specified element of the matrix to the provided value. If the matrix
+scope is `Wave`, this behaves as if called as `Set(WaveReadLaneFirst(V), Index)`.
+If the `Index` is out of range, this is a no-op.
+
+#### Matrix::MultiplyAccumuate(Matrix, Matrix)
+
+```c++
+template <typename T, uint K>
+  requires ArithmeticScalar<T>
+std::enable_if_t<Use == MatrixUse::Accumulator && Scope == MatrixScope::Wave,
+                 void>
+Matrix::MultiplyAccumulate(const Matrix<T, M, K, MatrixUse::A, Scope>,
+                           const Matrix<T, K, N, MatrixUse::B, Scope>);
+```
+
+A matrix with the `Accumulator` use and `Wave` scope has a method
+`MultiplyAccumulate` which takes as parameters an M x K `A` matrix and a K x N
+`B` matrix. The matrix arguments are multiplied against each other and added
+back into the implicit object `Accumulator` matrix.
+
+#### Matrix::SumAccumulate(Matrix, Matrix)
+
+```c++
+template <typename T>
+  requires ArithmeticScalar<T>
+std::enable_if_t<Use == MatrixUse::Accumulator, void>
+Matrix::SumAccumulate(const Matrix<T, N, M, MatrixUse::A, Scope>,
+              const Matrix<T, N, M, MatrixUse::B, Scope>);
+```
+
+A matrix with the `Accumulator` use and `Wave` scope has a method
+`SumAccumulate` which takes as parameters an M x K `A` matrix and a K x N
+`B` matrix. The matrix arguments are added together then added back into the
+implicit object `Accumulator` matrix.
+
+#### Matrix::OuterProductAccumulate(vector, vector)
+
+```c++
+template <typename T>
+std::enable_if_t<Use == MatrixUse::Accumulator, void>
+Matrix::OuterProductAccumulate(const vector<T, M> &, const vector<T, N> &);
+```
+
+A matrix with the `Accumulator` use has a method `OuterProductAccumulate` which
+takes an M-element vector and an N-element vector. The operation performs an
+outer product of the two vectors to produce an MxN matrix which is then added
+back into the implicit object `Accumulator` matrix.
+
+#### linalg::Multiply(Matrix, Matrix)
+
+```c++
+template <typename T, uint M, uint N, uint K>
+Matrix<T, M, N, MatrixUse::A, MatrixScope::Wave>
+linalg::Multiply(const Matrix<T, M, K, MatrixUse::A, MatrixScope::Wave>,
+         const Matrix<T, K, N, MatrixUse::B, MatrixScope::Wave>);
+```
+
+The `linalg::Multiply` function has an overload that takes an MxK `Wave`-scope
+`A` matrix, and a KxN `Wave`-scope `B` matrix and yields an MxN `Wave`-scope
+`Accumlator` matrix initialized with the product of the two input matrices.
+
+#### linalg::Multiply(vector, Matrix)
+
+``` c++
+template <typename OutputElTy, typename InputElTy, uint M, uint K,
+          MatrixComponentType MatrixDT, MatrixScope Scope, bool MatrixTranspose>
+vector<OutputElTy, K>
+linalg::Multiply(vector<InputElTy, M> InputVector,
+         Matrix<MatrixDT, M, K, MatrixUse::B, Scope> Matrix);
+```
+
+The `linalg::Multiply` function has an overload that takes an `M`-element vector
+and an MxK `B` matrix of any scope. The function returns a `K`-element vector.
+
+#### linalg::MultiplyAdd(vector, Matrix, vector)
+
+``` c++
+template <typename OutputElTy, typename InputElTy, typename BiasElTy, uint M,
+          uint K, MatrixComponentType MatrixDT, MatrixScope Scope,
+          bool MatrixTranspose>
+vector<OutputElTy, K>
+linalg::MultiplyAdd(vector<InputElTy, M> InputVector,
+            Matrix<MatrixDT, M, K, MatrixUse::B, Scope> Matrix,
+            vector<BiasElTy, K> BiasVector);
+```
+
+The `linalg::MultiplyAdd` function has an overload that takes an `M`-element, an
+MxK `B` matrix of any scope, and a `K`-element vector. The operation multiplies
+the `M`-element vector by the matrix then adds the `K`-element vector producing
+a result `K`-element vector.
 
 ### DXIL Enumerations
 

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -551,7 +551,8 @@ matrix.
 
 ```c++
 template <typename T, uint M, uint N, uint K>
-Matrix<T, M, N, MatrixUse::A, MatrixScope::Wave>
+Matrix<T, M, N, MatrixUse::Accumulator, MatrixScope::Wave>
+
 linalg::Multiply(const Matrix<T, M, K, MatrixUse::A, MatrixScope::Wave>,
          const Matrix<T, K, N, MatrixUse::B, MatrixScope::Wave>);
 ```

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -148,7 +148,8 @@ class Matrix {
 };
 
 template <typename T, uint M, uint N, uint K>
-Matrix<T, M, N, MatrixUse::A, MatrixScope::Wave>
+Matrix<T, M, N, MatrixUse::Accumulator, MatrixScope::Wave>
+
 Multiply(const Matrix<T, M, K, MatrixUse::A, MatrixScope::Wave>,
          const Matrix<T, K, N, MatrixUse::B, MatrixScope::Wave>);
 


### PR DESCRIPTION
This is a big revision to the `linalg::Matrix` proposal. There are a few substantial changes in this proposal to the API formulation.

First it updates the `Matrix` template so that the component type is specified as an enumeration rather than an explicit type. This allows specifying matrix types that are not HLSL built-in types.

Second, it adds two new arguments to the `Matrix` template: `Use` and `Scope`. The `MatrixUse` enumeration specifies the type of matrix as an `A`, `B`, or `Accumulator`. This aligns with the Vulkan cooperative_matrix naming rather than the earlier DirectX `Left` and `Right` naming in an effort to be less confusing to users who are supporting both platforms. The additional `MatrixScope` enumeration denotes the scope of uniformity that the matrix value is operating under. Wave-uniformity is required for matrix-matrix operations, however vector-matrix operations can operate on thread-divergent matrices.

This proposal adds support for vector-matrix operations subsuming the features described in [cooperative vectors](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0029-cooperative-vector.md).

Last, this proposal adds some rough initial DXIL operation specifications and updates the list of outstanding questions.