### PR TITLE
[0029] Clarify OOB bahavior for all Coopvec linalg builtins

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -250,7 +250,7 @@ row/column of the matrix is valid memory.
 The **matrix stride** is 16-byte aligned.
 
 This operation doesn't perform bounds checking for matrix loads. If any part of
-the matrix load is out of bounds then the entire operation is undefined.
+the matrix load is out of bounds then the entire matrix load will return zero.
 
 
 ##### Bias Vector
@@ -266,7 +266,7 @@ The base address of **bias vector resource** and **bias vector offset** must be
 64-byte aligned.
 
 This operation doesn't perform bounds checking for bias loads. If any part of
-the vector load is out of bounds then the entire operation is undefined.
+the vector load is out of bounds then the entire vector load will return zero.
 
 #### Return Type
 
@@ -336,6 +336,9 @@ row/column of the matrix is valid memory. Implementations may write to the
 contents of the padding between the end of the matrix and the 16-byte boundary,
 so developers should not use this padding space for anything else.
 
+If any part of the matrix write is out-of-bounds, the whole operation is
+skipped.
+
 Not all combinations of vector element type and matrix interpretations are
 supported by all implementations. [CheckFeatureSupport] can be used to
 determine which combinations are supported. A list of combinations that are
@@ -382,6 +385,9 @@ there is valid memory between the end of the array and the 16-byte boundary.
 Implementations may write to the contents of the padding between the end of the
 matrix and the 16-byte boundary, so developers should not use this padding space
 for anything else.
+
+If any part of the vector write is out-of-bounds, the whole operation is
+skipped.
 
 [CheckFeatureSupport] can be used to determine which vector element types can be
 accumulated. A list of types that are guaranteed to be supported on all devices


### PR DESCRIPTION
For Coopvec Linalg operations:
OOB Load: Entire load returns zero.
OOB Store: Entire Store is skipped.

spec changes per: https://github.com/microsoft/hlsl-specs/issues/458 