### PR TITLE
[0038] Mention handling of min16float type in isSpecialFloat 16 bit DXIL Op proposal

### DIFF
--- a/proposals/0038-16bit-isspecialfloat.md
+++ b/proposals/0038-16bit-isspecialfloat.md
@@ -44,7 +44,8 @@ via HLSL.
 There are no HLSL Additions.  The implementations for 16 bit float 'isinf',
 'isnan', and 'isfinite' will be updated to use emulation via LLVM IR for
 SM6.8 and earlier, and will generate the appropriate 16 bit DXIL Op in SM6.9
-and later.
+and later.  For the min16float type, the implementation will remain unchanged,
+DXC will continue to use the 32 bit DXIL ops.
 
 ### Interchange Format Additions
 


### PR DESCRIPTION
Mention how min16float type will be handled in the 16 bit isSpecialFloat dxil op proposal; the IR generated for it should remain unchanged.