### PR TITLE
[INF-0006][NFC] Fix proposal name collision

### DIFF
--- a/proposals/infra/INF-0006-Long-Vector-ExecutionTest-Plan.md
+++ b/proposals/infra/INF-0006-Long-Vector-ExecutionTest-Plan.md
@@ -1,6 +1,6 @@
 # Long Vector Execution Test Plan
 
-* Proposal: [0005](INF-0005-Long-Vector-ExecutionTest-Plan.md)
+* Proposal: [0006](INF-0006-Long-Vector-ExecutionTest-Plan.md)
 * Author(s): [Alex Sepkowski](https://github.com/alsepkow)
 * Sponsor: [Alex Sepkowski](https://github.com/alsepkow)
 * Status: **Accepted**


### PR DESCRIPTION
There was a collision between two proposals taking INF-0005, move the second landed one to INF-0006