### PR TITLE
Meeting minutes for 2025-07-22

### DIFF
--- a/docs/DesignMeetingMinutes/2025-07-22.md
+++ b/docs/DesignMeetingMinutes/2025-07-22.md
@@ -1,0 +1,69 @@
+# Design Meeting Minutes: 2025/07/22
+
+> NOTE: Please read the [terms of participation](DesignMeetingTerms.txt)
+> ("Terms") prior to joining the Teams meeting.  You joining the Teams meeting
+> with Microsoft indicates your acknowledgement, agreement, and consent to these
+> Terms.  If you do not agree to these Terms, please do not join the meeting.
+>
+> If you intend to contribute code or other copyrightable materials (e.g.
+> written comments, tools, documentation, etc.)  to the hlsl specs repository,
+> you are required to sign a Contributor License Agreement (CLA).  For details,
+> visit https://cla.microsoft.com.
+
+## Administrivia
+* No updates
+
+## Issues
+* No marked issues
+
+## PRs
+
+### Carried Forward
+
+* [[dxil] Proposal to add new debug printf dxil op](https://github.com/microsoft/hlsl-specs/pull/324)
+  * @tex3d will review this in more detail.
+* [[202x] Propose adding vk::SampledTexture* types](https://github.com/microsoft/hlsl-specs/pull/343)
+  * Ready to merge.
+* [Add proposal for scalar layout for constant buffers](https://github.com/microsoft/hlsl-specs/pull/317)
+  * Action Item @llvm-beanz - Move to merge.
+* [Rough proposal collecting thoughts on uniformity](https://github.com/microsoft/hlsl-specs/pull/405)
+  * Action Item: @llvm-beanz to update
+* [New Proposal: Draft proposal to modify resource typing in HLSL](https://github.com/microsoft/hlsl-specs/pull/461)
+  * Action Item: @llvm-beanz to work with author
+* [Memory and Execuition Model](https://github.com/microsoft/hlsl-specs/pull/505)
+  * Action Item: @llvm-beanz to continue iterating on the proposal.
+* [[0001] Consider targeting 202x for hlsl namespace](https://github.com/microsoft/hlsl-specs/issues/484)
+  * Revisit after namespace fixes in DXC go in.
+* [Remove unsized arrays](https://github.com/microsoft/hlsl-specs/issues/141)
+    * Action Item: @llvm-beanz follow up with @damyanp to find an owner for this.
+* [[0023] Adopt C++11 Base](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0023-cxx11-base.md)
+  * Action item: @llvm-beanz to complete design
+* [[0032] Constructors](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0032-constructors.md)
+  * Action item: @llvm-beanz to complete design [#526](https://github.com/microsoft/hlsl-specs/issues/526)
+
+### Current Business
+
+* housekeeping
+  * [PRs for meeting minutes](https://github.com/microsoft/hlsl-specs/pulls?q=is%3Apr+is%3Aopen+minutes)
+* HLSL 202y Proposals
+  * Call for acceptance
+    * [0004 - Unions](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0004-unions.md)
+      * No objections
+    * [0007 - Const member functions](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0007-const-member-functions.md)
+      * No objections
+    * [0008 - Non-member operator overloading](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0008-non-member-operator-overloading.md)
+      * No objections
+  * [[0002] Detail attributes that will replace HLSL annotations](https://github.com/microsoft/hlsl-specs/pull/534)
+    * Action item: @V-FEXrt & @tex3d
+  * [[0005] Adding spec language for strict initializer lists](https://github.com/microsoft/hlsl-specs/pull/522)
+    * Action item: @bogner & @tex3d
+
+
+### SM 6.9
+
+* [[Shader Execution Reordering] Minor spec inconsistency: HitObject::MakeMiss missing Ray in argument listing](https://github.com/microsoft/hlsl-specs/pull/512)
+* [Proposal for 16 bit IsSpecialFloat dxil op](https://github.com/microsoft/hlsl-specs/pull/542)
+  * These operations were originally added in SM 6.2, however a bug in DXC prevented them from being emitted and tested. We've found IHV drivers in the wild that crash or generate invalid code for these operations so we've decided to retroactively remove them from SM 6.2->6.8 and add them back in 6.9.
+  * Action item: @tex3d to review
+
+## Other Discussion


### PR DESCRIPTION
Add the meeting minutes for the 2025-07-22 meeting. This includes calls to accept proposals 0004, 0007, and 0008 to HLSL 202y.