### PR TITLE
[0026] Clarify Buffer Memory layout

### DIFF
--- a/proposals/0026-hlsl-long-vector-type.md
+++ b/proposals/0026-hlsl-long-vector-type.md
@@ -118,12 +118,12 @@ myBuffer.Store< vector<T, N> >(StartoffsetInBytes + 100, val);
 
 ```
 
-Long Vectors initialzed from or dumped to a Raw Buffer must comply with the 
+Long Vectors initialized from or dumped to a Raw Buffer must comply with the
 alignment rules of the underlying buffer. Therefore a vector `Load`ed or `Store`d
 to a `ByteAddressBuffer` must either naturally align to or be padded to 4 bytes.
 Misaligned offsets results in undefined behavior. APIs built on top of Long Vectors
 such as Cooperative Vectors or Cooperative Matrix may further restrict memory
-alignment requirements but that is not specified or manidated by this spec.
+alignment requirements but that is not specified or mandated by this spec.
 
 StructuredBuffers with N-element vectors are declared using the template syntax
  with a long vector type as the template parameter.

--- a/proposals/0026-hlsl-long-vector-type.md
+++ b/proposals/0026-hlsl-long-vector-type.md
@@ -118,6 +118,13 @@ myBuffer.Store< vector<T, N> >(StartoffsetInBytes + 100, val);
 
 ```
 
+Long Vectors initialzed from or dumped to a Raw Buffer must comply with the 
+alignment rules of the underlying buffer. Therefore a vector `Load`ed or `Store`d
+to a `ByteAddressBuffer` must either naturally align to or be padded to 4 bytes.
+Misaligned offsets results in undefined behavior. APIs built on top of Long Vectors
+such as Cooperative Vectors or Cooperative Matrix may further restrict memory
+alignment requirements but that is not specified or manidated by this spec.
+
 StructuredBuffers with N-element vectors are declared using the template syntax
  with a long vector type as the template parameter.
 N-element vectors are loaded and stored from ByteAddressBuffers using the templated load and store methods

--- a/proposals/0026-hlsl-long-vector-type.md
+++ b/proposals/0026-hlsl-long-vector-type.md
@@ -119,11 +119,12 @@ myBuffer.Store< vector<T, N> >(StartoffsetInBytes + 100, val);
 ```
 
 Long Vectors initialized from or dumped to a Raw Buffer must comply with the
-alignment rules of the underlying buffer. Therefore a vector `Load`ed or `Store`d
-to a `ByteAddressBuffer` must either naturally align to or be padded to 4 bytes.
-Misaligned offsets results in undefined behavior. APIs built on top of Long Vectors
-such as Cooperative Vectors or Cooperative Matrix may further restrict memory
-alignment requirements but that is not specified or mandated by this spec.
+alignment rules of the underlying buffer. Therefore the offset used to `Load`/`Store`
+a vector from/to a `ByteAddressBuffer` must be aligned to a multiple of the component
+type. (EX: half -> 2 bytes, uint -> 4 bytes, int64 -> 8 bytes). Misaligned offsets
+result in undefined behavior. APIs built on top of Long Vectors such as Cooperative
+Vectors or Cooperative Matrix may further restrict memory alignment requirements but
+that is not required by this spec.
 
 StructuredBuffers with N-element vectors are declared using the template syntax
  with a long vector type as the template parameter.

--- a/proposals/0026-hlsl-long-vector-type.md
+++ b/proposals/0026-hlsl-long-vector-type.md
@@ -118,11 +118,11 @@ myBuffer.Store< vector<T, N> >(StartoffsetInBytes + 100, val);
 
 ```
 
-Long Vectors initialized from or dumped to a Raw Buffer must comply with the
-alignment rules of the underlying buffer. Therefore the offset used to `Load`/`Store`
-a vector from/to a `ByteAddressBuffer` must be aligned to a multiple of the component
-type. (EX: half -> 2 bytes, uint -> 4 bytes, int64 -> 8 bytes). Misaligned offsets
-result in undefined behavior.
+Long Vectors loaded from or stored to a Raw Buffer must comply with the alignment
+rules of the underlying buffer. Therefore the offset used to `Load`/`Store` a vector
+from/to a `ByteAddressBuffer` must be aligned to a multiple of the component type.
+(EX: half -> 2 bytes, uint -> 4 bytes, int64 -> 8 bytes). Misaligned offsets result 
+in undefined behavior.
 
 StructuredBuffers with N-element vectors are declared using the template syntax
  with a long vector type as the template parameter.

--- a/proposals/0026-hlsl-long-vector-type.md
+++ b/proposals/0026-hlsl-long-vector-type.md
@@ -122,9 +122,7 @@ Long Vectors initialized from or dumped to a Raw Buffer must comply with the
 alignment rules of the underlying buffer. Therefore the offset used to `Load`/`Store`
 a vector from/to a `ByteAddressBuffer` must be aligned to a multiple of the component
 type. (EX: half -> 2 bytes, uint -> 4 bytes, int64 -> 8 bytes). Misaligned offsets
-result in undefined behavior. APIs built on top of Long Vectors such as Cooperative
-Vectors or Cooperative Matrix may further restrict memory alignment requirements but
-that is not required by this spec.
+result in undefined behavior.
 
 StructuredBuffers with N-element vectors are declared using the template syntax
  with a long vector type as the template parameter.


### PR DESCRIPTION
Fixes #543 

Updates the spec to explicitly state that `Load`/`Store` of a vector into/out of a Raw Buffer requires alignment of the underlying buffer and that consuming APIs are allowed to further restrict alignment.