### PR TITLE
Add clarifications on usage of intangible objects

### DIFF
--- a/specs/language/basic.tex
+++ b/specs/language/basic.tex
@@ -420,8 +420,8 @@ resources in cbuffer declarations, but it does so by hoisting the resource
 declaration out to the global scope.}
 
 \item An object of intangible type may not be a parameter or return type of a
-function with program linkage or external linkage (\ref{Basic.Linkage.Program} &
-\ref{Basic.Linkage.External}).
+function with program linkage or external linkage (\ref{Basic.Linkage.Program}
+and \ref{Basic.Linkage.External}).
 \end{itemize}
 
 \Sec{Lvalues and rvalues}{Basic.lval}


### PR DESCRIPTION
This adds clarifications to the language specification on the allowed usage of objects of intangible types.

This is in response to a comment by @dneto0 on the linalg::Matrix PR:

https://github.com/microsoft/hlsl-specs/pull/556#discussion_r2217019792