### PR TITLE
[0030] Fix Op Class for vector dot,and,or

### DIFF
--- a/proposals/0030-dxil-vectors.md
+++ b/proposals/0030-dxil-vectors.md
@@ -138,7 +138,7 @@ This means that the same language-level vector (of any length) could be used
 
 #### `VectorReduce` OpCodeClass
 
-A new generic OpCodeClass `VectorReduce` is introduce for usage in new operations
+A new generic OpCodeClass `VectorReduce` is introduced for usage in new operations
 below. `VectorReduce` combines a vector of elements into a single element with
 the same type as the vector element type. The elements are combined using an
 operation specified by the opcode parameter.


### PR DESCRIPTION
Corrects the op class for the three new vector reduction operations previously specified.

These operations return their element type instead of a returning a vector matching the parameter type.

Also takes the opportunity to explicitly call out the allowed scalar types.