### PR TITLE
[0035] Add `MatrixScope::ThreadGroup`

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -598,8 +598,8 @@ Matrix::Splat(T Val);
 ```
 
 Constructs a matrix filled with the provided value casted to the element type.
-If the matrix is a `Wave` or `ThreadGroup` scope matrix, this operation shall behave equivalent
-to:
+If the matrix is a `Wave` or `ThreadGroup` scope matrix, this operation shall
+behave equivalent to:
 
 ```c++
 Matrix::Splat(WaveReadLaneFirst(Val));
@@ -607,7 +607,7 @@ Matrix::Splat(WaveReadLaneFirst(Val));
 
 This operation may be called in divergent control flow when creating a thread
 scope matrix, and must be called in uniform control flow when creating a wave
-scope matrix.
+scope or thread group scope matrix.
 
 #### Matrix::Load
 


### PR DESCRIPTION
This PR adds support for thread group scope matrices to the specification.

See Issue #577.