### PR TITLE
[0040] Select type support proposal

### DIFF
--- a/proposals/0040-select-type-support.md
+++ b/proposals/0040-select-type-support.md
@@ -1,5 +1,5 @@
 ---
-title: "NNNN - Select type support"
+title: "0040 - Select type support"
 params:
   authors:
     - kmpeng: Kaitlin Peng


### PR DESCRIPTION
Language proposal for allowing Clang's `select` implementation to work with more general types (e.g. structs and arrays) instead of limiting it to the types allowed in DXC.