### PR TITLE
[0041] TriangleObjectPositions proposal

### DIFF
--- a/proposals/0041-triangle-object-positions.md
+++ b/proposals/0041-triangle-object-positions.md
@@ -1,5 +1,5 @@
 --- 
-title: NNNN - TriangleObjectPositions
+title: 0041 - TriangleObjectPositions
 params:
   authors:
   - tex3d: Tex Riddell


### PR DESCRIPTION
Replaces #571 and #572.

I've also fleshed out the doc slightly, to codify that this is targeting shader model 6.10, and now that shader model 6.9 is available, to unresolve the DXIL opcode discussion about return type to mention that `float3` and `vector<float, 9>` are available as options. I added a SPIR-V section and references to DXIL SER as well.