### PR TITLE
[0035] Re-add support for OuterProduct and Accumulate for Thread Scope Matrices

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -785,7 +785,7 @@ Accumulate(/*groupshared*/ T Arr[], uint StartIdx, uint Stride, MatrixLayout Lay
 The matrix `Accumulate` methods add the matrix data to a target
 `RWByteAddressBuffer` or `groupshared` array. These methods are only available
 for matrices with `MatrixUse::Accumulator`. The `RWByteAddressBuffer` overload
-works with all thread scopes, while the `groupshared` overload only works with
+works with all matrix scopes, while the `groupshared` overload only works with
 `Wave` scope matrices. When accumulating to `RWByteAddressBuffer` objects the
 data is added in the component type of the matrix object. When accumulating to
 `groupshared` memory, the matrix component data is converted to the target

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1244,6 +1244,55 @@ a bias vector added to the result.
 
 > Note for this operation the matrix can be of any scope.
 
+```llvm
+declare void @dx.op.matrixAccumulateToDescriptor(
+  immarg i32,            ; opcode
+  %dx.types.MatrixRef *, ; matrix
+  %dx.types.Handle *,    ; RWByteAddressBuffer
+  i32,                   ; Offset
+  i32,                   ; Stride
+  i32                    ; matrix layout
+  )
+```
+
+Accumulates a matrix to a RWByteAddressBuffer at a specified offset. This
+operation is only available for matrices with `MatrixUse::Accumulator`. The
+matrix data is added to the existing data in the buffer. If any destination
+address is out of bounds the entire accumulate operation is a no-op.
+
+```llvm
+declare void @dx.op.matrixAccumulateToMemory.p[Ty](
+  immarg i32,            ; opcode
+  %dx.types.MatrixRef *, ; matrix
+  [Ty] *,                ; groupshared T[M * N]
+  i32,                   ; Offset
+  i32,                   ; Stride
+  i32                    ; matrix layout
+  )
+```
+
+Accumulates a matrix to groupshared memory. This operation is only available
+for matrices with `MatrixUse::Accumulator` and `Wave` scope. The matrix
+component data is converted to the target arithmetic or packed data type if the
+data types do not match, then added to the existing data in memory.
+
+```llvm
+declare %dx.types.MatrixRef *@dx.op.matrixOuterProduct(
+  immarg i32,            ; opcode
+  immarg i32,            ; component type (DXILMatrixComponentType)
+  immarg i32,            ; M dimension
+  immarg i32,            ; N dimension
+  immarg i32,            ; matrix Scope (DXILMatrixScope)
+  <[M] x [Ty]>,          ; vector A
+  <[N] x [Ty]>           ; vector B
+  )
+```
+
+Creates a new MxN accumulator matrix initialized with the outer product of the
+two input vectors. The matrix scope can be `Thread`, `Wave`, or `ThreadGroup`.
+The element type of the output matrix matches the element type of the input
+vectors.
+
 ### Conversions
 
 ## Appendix 1: Outstanding Questions

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -290,7 +290,7 @@ void OuterProdAccum() {
   vector<float16_t, 8> VecB = (vector<float16_t, 8>)0;
   MatrixAccumTy MatAcc = OuterProduct<MatrixComponentType::F16, MatrixScope::Thread>(VecA, VecB);
   
-  MatAcc.Accumulate(Buf, 0, 16 * 2, MatrixLayout::OuterProductOptimal);
+  MatAcc.Accumulate(Buf, 0, 0, MatrixLayout::OuterProductOptimal);
 }
 ```
 
@@ -693,6 +693,9 @@ unsupported:
 | `Matrix::Load(ByteAddressBuffer)` | `Thread` | any |
 | `Matrix::Load(*)` | `Wave` | `RowMajor`, `ColMajor` |
 
+If the `Layout` argument is `MulOptimal` or `OuterProductOptimal`, then
+the `Stride` must be `0`.
+
 This operation may be called in divergent control flow when loading a thread
 scope matrix, and must be called in uniform control flow when loading a wave
 scope matrix.
@@ -796,6 +799,9 @@ are unsupported:
 |-----------|--------------|------------|
 | `Matrix::Accumulate(RWByteAddressBuffer)` | `Thread` | `OuterProductOptimal` |
 | `Matrix::Accumulate(*)` | `Wave` | `RowMajor`, `ColMajor` |
+
+If the `Layout` argument is `OuterProductOptimal`, then the `Stride` must be
+`0`.
 
 #### Matrix::GetThreadVector(uint)
 
@@ -1252,7 +1258,7 @@ a bias vector added to the result.
 
 ## Appendix 2: HLSL Header
 
-[Compiler Explorer](https://godbolt.org/z/dh9jzbj8K)
+[Compiler Explorer](https://godbolt.org/z/qYW89nTTK)
 > Note: this mostly works with Clang, but has some issues to work out still.
 
 ```cpp
@@ -1588,7 +1594,7 @@ void OuterProdAccum() {
   vector<float16_t, 8> VecB = (vector<float16_t, 8>)0;
   MatrixAccumTy MatAcc = OuterProduct<MatrixComponentType::F16, MatrixScope::Thread>(VecA, VecB);
   
-  MatAcc.Accumulate(Buf, 0, 16 * 2, MatrixLayout::OuterProductOptimal);
+  MatAcc.Accumulate(Buf, 0, 0, MatrixLayout::OuterProductOptimal);
 }
 ```
 


### PR DESCRIPTION
This PR replaces `Matrix::OuterProductAccumulate()` with `linalg::OuterProduct()` and `Matrix::Accumulate()`.  The objective with this change is to support a method for OuterProduct and Accumulate for Thread scope matrices.  It also extends the `MatrixLayout` enumeration and adds constraints for their usage.