### PR TITLE
[0029] Mark cooperative vectors proposal as rejected

### DIFF
--- a/proposals/0029-cooperative-vector.md
+++ b/proposals/0029-cooperative-vector.md
@@ -8,9 +8,10 @@ params:
   sponsors:
   - damyanp: Damyan Pepper
   - pow2clk: Greg Roth
-  status: Under Review
+  status: Rejected
 ---
 
+> This has been superceded by [0035-linalg-matrix.md](0035-linalg-matrix.md)
 
  
 * Planned Version: SM 6.9


### PR DESCRIPTION
The functionality provided by this proposal is now being exposed through [0035-linalg-matrix.md](0035-linalg-matrix.md).

See https://devblogs.microsoft.com/directx/shader-model-6-9-and-the-future-of-cooperative-vector/ for more context.
