### PR TITLE
Meeting minutes and notes for 2025-09-16

### DIFF
--- a/docs/DesignMeetingMinutes/2025-09-16.md
+++ b/docs/DesignMeetingMinutes/2025-09-16.md
@@ -45,10 +45,13 @@ title: "Design Meeting Minutes: 2025/09/16"
 
 * [[0002] Detail attributes that will replace HLSL annotations](https://github.com/microsoft/hlsl-specs/pull/534)
   * Updates needing re-review
+  * Action Item: Ashley and Helena to review.
 * [[0042] - Restricted Unbounded Arrays](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0042-restricted-unbounded-arrays.md)
   * [Remove unsized arrays](https://github.com/microsoft/hlsl-specs/issues/141)
   * Related spec PR - [#634](https://github.com/microsoft/hlsl-specs/pull/634)
+  * Jesse confirmed Unity's codebase does not depend on zero-size arrays.
 * [[NEW] Proposal for `groupshared` arguments](https://github.com/microsoft/hlsl-specs/pull/631)
+  * Action Item: Tex to review
 * [Should explicit casts ever create l-values?](https://github.com/microsoft/hlsl-specs/issues/639)
 
 


### PR DESCRIPTION
This adds the meeting minutes doc updated and fleshed out with topics for this week's discussions.

Note: I'm posting this initially before the meeting to serve as an agenda.