### PR TITLE
[0031] Mark the HLSL Vector Matrix Operations proposal as rejected

### DIFF
--- a/proposals/0031-hlsl-vector-matrix-operations.md
+++ b/proposals/0031-hlsl-vector-matrix-operations.md
@@ -7,7 +7,7 @@ params:
   - anupamachandra: Anupama Chandrasekhar
   sponsors:
   - damyanp: Damyan Pepper
-  status: Under Review
+  status: Rejected
 ---
 
 


### PR DESCRIPTION
The functionality provided by this proposal is now being exposed through [0035-linalg-matrix.md](0035-linalg-matrix.md).

See https://devblogs.microsoft.com/directx/shader-model-6-9-and-the-future-of-cooperative-vector/ for more context.
