### PR TITLE
[0035] Matrix dimensions HLSL and container handling

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -413,7 +413,7 @@ hardware implementation.
 #### Restrictions on Dimensions
 
 The HLSL API will enforce restrictions on the `K` dimension as found in the
-formula: `MxK * K*N = MxN`
+formula: `MxK * KxN = MxN`
 
 This restriction impacts the number of rows in an A matrix, and columns in a B
 matrix, but has no impact on an accumulator matrix.

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1350,25 +1350,22 @@ The `MatrixUse` object is defined:
 ```c
 struct MatrixUse {
   uint32_t Dimensions[3]; // M, N, K
-  uint32_t Scope;
+  uint8_t Scope;
+  uint8_t OperandType;
+  uint8_t ResultType;
+  uint8_t RESERVED; // unused but reserved for padding/alignment.
   uint32_t Flags; // do we need this?
-  uint32_t OperandType;
-  uint32_t ResultType;
 };
 ```
 
 This object will encode each matrix shape and element type as used by the DXIL
 operations in the `matrixOp` and `matvecmuladd` opcode classes.
 
-The Scope field will encode one of the values defined in the enumeration:
+The Scope field will encode one of the values defined in the [`DXILMatrixScope`
+enumeration](#dxil-enumerations).
 
-```c
-enum MatrixScope {
-  Thread = 1,
-  Wave = 2,
-  ThreadGroup = 3,
-};
-```
+The `OperandType` and `ResultType` fields will encode one of the values defined
+in the [`DXILMatrixComponentType` enumeration](#dxil-enumerations).
 
 > Open questions:
 > 1) Do we need the M and N dimensions or just the K dimension?


### PR DESCRIPTION
This adds some size constriants for matrices in the HLSL types as well as a draft for how the matrix shapes and types will be captured in the PSV runtime information for the D3D runtime to inspect.

Fixes #586