### PR TITLE
[0035] Rework elementwise operations

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -737,8 +737,8 @@ Matrix::Length();
 
 Returns the number of matrix components accessible to the current thread. The
 mapping and distribution of threads to matrix elements is opaque and
-implementation-specific. The value returned by `Length` may not be the same
-across all threads. The sum of the values returned by `Length` across all
+implementation-specific. The value returned by `Length` may be different
+for each thread. The sum of the values returned by `Length` across all
 threads must be greater than or equal to the total number of matrix elements.
 Some implementations may map multiple threads to the same matrix element.
 Therefore, developers should take this into consideration when programming


### PR DESCRIPTION
This revises elementwise operations to more closely align with SPIRV. The main changes here are:

* Removal of the APIs to create a matrix from per-thread vectors.
* Removal of the APIs to split a matrix into per-thread vectors.
* Removal of ApplyUnaryOperation API.
* Addition of Length API to query the number of elements stored locally in a thread.
* Addition of GetCoordinate API to convert a thread-local index to column and row.
* Addition of Get and Set APIs that use thread-local indices.
* Elementwise addition, subtraction, multiply and divide are implemented in HLSL, removing the binop DXIL operations.

Fixes #623