### PR TITLE
Fix broken link for long vector execution tests

### DIFF
--- a/proposals/0026-hlsl-long-vector-type.md
+++ b/proposals/0026-hlsl-long-vector-type.md
@@ -322,7 +322,7 @@ Correct behavior for all of the intrinsics listed in [allowed elementwise vector
  will be verified with execution tests that perform the operations on long vectors and confirm correct results
  for the given test values.
 Where possible, these tests will be variations on existing tests for these
-intrinsics. [Long-Vector-ExecutionTest-Plan](./infra/INF-0005-Long-Vector-ExecutionTest-Plan.md)
+intrinsics. [Long-Vector-ExecutionTest-Plan](./infra/INF-0006-Long-Vector-ExecutionTest-Plan.md)
 
 ## Alternatives considered
 


### PR DESCRIPTION
The name of the long vector execution test plan was changed.