### PR TITLE
[0033] Update DXIL 1.9

### DIFF
--- a/proposals/0033-dxil19.md
+++ b/proposals/0033-dxil19.md
@@ -9,7 +9,7 @@ params:
 ---
 
 
- 
+
 * Planned Version: SM 6.9
 
 ## Introduction
@@ -18,21 +18,23 @@ Shader Model 6.9 introduces new features to HLSL which need representations in
 DXIL.  This proposal provides an index of the new features:
 
 
-## Opacity Micromaps
+## New DXIL Features
+
+### Opacity Micromaps
 
 [Proposal 0024] - Opacity Micromaps (OMM)
 
 This adds a new DXIL op, `AllocateRayQuery2` and some new flags.
 
 
-## Shader Execution Reordering
+### Shader Execution Reordering
 
 [Proposal 0027] - Shader Execution Reordering (SER)
 
 This adds a new DXIL type, `%dx.types.HitObject` and 30 new DXIL ops.
 
 
-## DXIL Vectors
+### DXIL Vectors
 
 [Proposal 0030] - DXIL Vectors
 
@@ -43,7 +45,7 @@ intrinsics are extended to accept vector arguments.
 The HLSL changes related to this feature can be found in [Proposal 0026] - HLSL
 Long Vector Type.
 
-## 16bit IsSpecialFloat
+### 16bit IsSpecialFloat
 
 [Proposal 0038] - 16bit IsSpecialFloat
 
@@ -51,11 +53,37 @@ The IsSpecialFloat DXIL Ops are used to implement operations, 'isinf', 'isnan',
 'isfinite', and 'isnormal'. Due to a bug (#7496), the IsSpecialFloat DXIL
 operations were never generated for 16-bit types.  This bug is fixed for SM 6.9.
 
+## Non-breaking Changes
+
+[Proposal 0044] - SM 6.9 Required Features
+
+This proposal adds new required feature support for all DXIL 1.9
+implementations. All DXIL 1.9 shaders may freely use 16-bit native data types,
+wave operations and 64bit integers. This proposal does not change the DXIL
+representation or the collection of flags in the shader binary, but a conforming
+implementation that accepts DXIL 1.9 must also always support these features.
+
+## Deferred Features
+
+The following features previewed in 6.9 and originally planned as DXIL 1.9
+features, but are deferred to a later release.
+
+### Cooperative Vector
+
+[Proposal 0031] - Cooperative Vector
+
+Cooperative vector added new vector-matrix multiplication and accumulation
+operations to expose GPU hardware acceleration for SIMD-cooperative linear
+algebra operations on matrices and vectors with dimensions larger than four.
+[Proposal 0035] supersedes this and targets a later release.
 
 
 [Proposal 0024]: 0024-opacity-micromaps.md
 [Proposal 0026]: 0026-hlsl-long-vector-type.md
 [Proposal 0027]: 0027-shader-execution-reordering.md
+[Proposal 0029]: 0029-cooperative-vector.md
 [Proposal 0030]: 0030-dxil-vectors.md
+[Proposal 0035]: 0035-linalg-matrix.md
 [Proposal 0038]: 0038-16bit-isspecialfloat.md
+[Proposal 0044]: 0044-sm69-required-features.md
 


### PR DESCRIPTION
Added a section on non-breaking changes to link proposal 44, and a section on deferred features to cite cooperative vector.

This gives us one document with the full status of SM 6.9 that we can link to partners.