### PR TITLE
[HLSL] define the matrix element accessor semantics

### DIFF
--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -245,7 +245,7 @@ postfix expression before the dot.
   matrix-zero-indexed-swizzle-sequence matrix-zero-indexed-swizzle\br
 
   \define{matrix-zero-indexed-swizzle}\br
-  \terminal{\_m} zero-index-value\br
+  \terminal{\_m} zero-index-value zero-index-value\br
 
   \define{zero-index-value} \textnormal{one of}\br
   \terminal{0 1 2 3 }\br
@@ -255,7 +255,7 @@ postfix expression before the dot.
   matrix-one-indexed-swizzle-sequence matrix-one-indexed-swizzle\br
 
   \define{matrix-one-indexed-swizzle}\br
-  \terminal{\_m} one-index-value\br
+  \terminal{\_} one-index-value one-index-value\br
 
   \define{one-index-value} \textnormal{one of}\br
   \terminal{1 2 3 4 }\br


### PR DESCRIPTION
fixes #677

Moved the Vector Swizzle stuff that repeats with Matrix and moved it to a generic swizzle section.
<img width="930" height="250" alt="image" src="https://github.com/user-attachments/assets/e57376cb-12a3-44ea-8bee-0db81ed01fc1" />


The new Matrix Swizzle looks like this:
<img width="1170" height="1040" alt="image" src="https://github.com/user-attachments/assets/96b8e130-8e8e-436d-b367-fc9c2f2c5ad9" />


<img width="1434" height="654" alt="image" src="https://github.com/user-attachments/assets/27d283cd-06a2-41de-a902-411f085b7344" />



