### PR TITLE
[Expr.Post.VectorSwizzle] Vector member swizzles

### DIFF
--- a/specs/language/expressions.tex
+++ b/specs/language/expressions.tex
@@ -188,17 +188,11 @@ range at runtime, the behavior is undefined.
   swizzle-component-xyzw\br
   swizzle-component-sequence-xyzw swizzle-component-xyzw\br
 
-  \define{swizzle-component-rgba}\br
-  \terminal{r}\br
-  \terminal{g}\br
-  \terminal{b}\br
-  \terminal{a}\br
+  \define{swizzle-component-rgba} \textnormal{one of}\br
+  \terminal{r g b a}\br
 
-  \define{swizzle-component-xyzw}\br
-  \terminal{x}\br
-  \terminal{y}\br
-  \terminal{z}\br
-  \terminal{w}
+  \define{swizzle-component-xyzw} \textnormal{one of}\br
+  \terminal{x y z w}
 \end{grammar}
 
 \p A \textit{postfix-expression} followed by a dot (\texttt{.}) and a sequence


### PR DESCRIPTION
This PR adds specification language for vector member swizzles to clarify how swizzles are parsed, how the fit in the grammar, what the component accesses mean, and whether the expression produces an lvalue or a prvalue.

Rendering of the grammar:
<img width="635" height="623" alt="Screenshot 2025-10-14 at 3 14 39 PM" src="https://github.com/user-attachments/assets/3c3feb5b-fd31-47d5-863f-7166a71d6fda" />
