### PR TITLE
[0035] Remove operator overloads

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -76,47 +76,6 @@ class Matrix {
                            Matrix<NewCompTy, M, N, NewUse, Scope>>::type
   Cast();
 
-  // Element-wise operations
-  template <typename T>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               Scope != MatrixScope::Thread,
-                           Matrix>::type
-  operator+=(T V) {
-    for (uint I = 0; I < Length(); ++I)
-      Set(I, Get(I) + V);
-    return this;
-  }
-
-  template <typename T>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               Scope != MatrixScope::Thread,
-                           Matrix>::type
-  operator-=(T V) {
-    for (uint I = 0; I < Length(); ++I)
-      Set(I, Get(I) - V);
-    return this;
-  }
-
-  template <typename T>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               Scope != MatrixScope::Thread,
-                           Matrix>::type
-  operator*=(T V) {
-    for (uint I = 0; I < Length(); ++I)
-      Set(I, Get(I) * V);
-    return this;
-  }
-
-  template <typename T>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               Scope != MatrixScope::Thread,
-                           Matrix>::type
-  operator/=(T V) {
-    for (uint I = 0; I < Length(); ++I)
-      Set(I, Get(I) / V);
-    return this;
-  }
-
   template <typename T>
   static typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
                                       Scope != MatrixScope::Thread,
@@ -385,11 +344,7 @@ The following table summarizes the operations supported for each matrix scope:
 
 | Operation | Thread Scope | Wave Scope | ThreadGroup Scope |
 |-----------|--------------|------------|-------------------|
-| `Matrix::cast()` | ✗ | ✓ | ✓ |
-| `Matrix::operator+=()` | ✗ | ✓ | ✓ |
-| `Matrix::operator-=()` | ✗ | ✓ | ✓ |
-| `Matrix::operator*=()` | ✗ | ✓ | ✓ |
-| `Matrix::operator/=()` | ✗ | ✓ | ✓ |
+| `Matrix::Cast()` | ✗ | ✓ | ✓ |
 | `Matrix::Length()` | ✗ | ✓ | ✓ |
 | `Matrix::GetCoordinate(uint)` | ✗ | ✓ | ✓ |
 | `Matrix::Get(uint)` | ✗ | ✓ | ✓ |
@@ -635,31 +590,6 @@ Matrix::Cast();
 ```
 
 The `Matrix::Cast()` function supports casting component types and matrix `Use`.
-
-#### Element-wise Operators
-
-```c++
-template <typename T>
-typename hlsl::enable_if<
-    hlsl::is_arithmetic<T>::value && Scope != MatrixScope::Thread, Matrix>::type
-    Matrix::operator+=(T);
-template <typename T>
-typename hlsl::enable_if<
-    hlsl::is_arithmetic<T>::value && Scope != MatrixScope::Thread, Matrix>::type
-    Matrix::operator-=(T);
-template <typename T>
-typename hlsl::enable_if<
-    hlsl::is_arithmetic<T>::value && Scope != MatrixScope::Thread, Matrix>::type
-    Matrix::operator*=(T);
-template <typename T>
-typename hlsl::enable_if<
-    hlsl::is_arithmetic<T>::value && Scope != MatrixScope::Thread, Matrix>::type
-    Matrix::operator/=(T);
-```
-
-For any arithmetic scalar type the `+`, `-`, `*` and `/` binary operators
-perform element-wise arithmetic on the matrix. The returned by-value `Matrix`
-contains the same handle and refers to the same (now modified) `Matrix`.
 
 #### Matrix::Splat(T)
 
@@ -1397,7 +1327,7 @@ in the [`DXILMatrixComponentType` enumeration](#dxil-enumerations).
 
 ## Appendix 2: HLSL Header
 
-[Compiler Explorer](https://godbolt.org/z/eY8bYvdo7)
+[Compiler Explorer](https://godbolt.org/z/GMz4T1bh8)
 > Note: this mostly works with Clang, but has some issues to work out still.
 
 ```cpp
@@ -1526,47 +1456,6 @@ class Matrix {
                            Matrix<NewCompTy, M, N, NewUse, Scope>>::type
   Cast();
 
-  // Element-wise operations
-  template <typename T>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               Scope != MatrixScope::Thread,
-                           Matrix>::type
-  operator+=(T V) {
-    for (uint I = 0; I < Length(); ++I)
-      Set(I, Get(I) + V);
-    return this;
-  }
-
-  template <typename T>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               Scope != MatrixScope::Thread,
-                           Matrix>::type
-  operator-=(T V) {
-    for (uint I = 0; I < Length(); ++I)
-      Set(I, Get(I) - V);
-    return this;
-  }
-
-  template <typename T>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               Scope != MatrixScope::Thread,
-                           Matrix>::type
-  operator*=(T V) {
-    for (uint I = 0; I < Length(); ++I)
-      Set(I, Get(I) * V);
-    return this;
-  }
-
-  template <typename T>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               Scope != MatrixScope::Thread,
-                           Matrix>::type
-  operator/=(T V) {
-    for (uint I = 0; I < Length(); ++I)
-      Set(I, Get(I) / V);
-    return this;
-  }
-
   template <typename T>
   static typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
                                       Scope != MatrixScope::Thread,
@@ -1680,14 +1569,16 @@ Multiply(const Matrix<T, M, K, MatrixUse::A, MatrixScope::ThreadGroup>,
 
 template <typename OutputElTy, typename InputElTy, uint M, uint K,
           MatrixComponentType MatrixDT>
-vector<OutputElTy, K> Multiply(vector<InputElTy, M>,
-                               Matrix<MatrixDT, M, K, MatrixUse::B, MatrixScope::Thread>);
+vector<OutputElTy, K>
+    Multiply(vector<InputElTy, M>,
+             Matrix<MatrixDT, M, K, MatrixUse::B, MatrixScope::Thread>);
 
 template <typename OutputElTy, typename InputElTy, typename BiasElTy, uint M,
           uint K, MatrixComponentType MatrixDT>
-vector<OutputElTy, K> MultiplyAdd(vector<InputElTy, M>,
-                                  Matrix<MatrixDT, M, K, MatrixUse::B, MatrixScope::Thread>,
-                                  vector<BiasElTy, K>);
+vector<OutputElTy, K>
+    MultiplyAdd(vector<InputElTy, M>,
+                Matrix<MatrixDT, M, K, MatrixUse::B, MatrixScope::Thread>,
+                vector<BiasElTy, K>);
 
 // Outer product functions
 template <MatrixComponentType OutTy, MatrixScope Scope, typename InputElTy,
@@ -1731,8 +1622,8 @@ ByteAddressBuffer MBuf : register(t0);
 
 void CoopVec() {
   using namespace dx::linalg;
-  using MatrixBTy =
-      Matrix<MatrixComponentType::F16, 32, 16, MatrixUse::B, MatrixScope::Thread>;
+  using MatrixBTy = Matrix<MatrixComponentType::F16, 32, 16, MatrixUse::B,
+                           MatrixScope::Thread>;
 
   vector<float16_t, 32> Vec = (vector<float16_t, 32>)0;
   MatrixBTy MatB = MatrixBTy::Load(MBuf, 0, 32 * 4, MatrixLayout::RowMajor);


### PR DESCRIPTION
We had a discussion around the API design and decided to remove the elementwise operators. Since they are implementable in HLSL they aren't providing extra required functionality and the usage of operators on handle objects or matrices themselves can be a bit unintuitive.