### PR TITLE
HLSL Group Wave Index Proposal

### DIFF
--- a/proposals/0048-group-wave-index.md
+++ b/proposals/0048-group-wave-index.md
@@ -1,5 +1,5 @@
 ---
-title: "NNNN - Group Wave Index"
+title: "0048 - Group Wave Index"
 params:
     authors:
     - MartinAtXbox: Martin Fuller


### PR DESCRIPTION
Proposal of a new shader semantic for Compute, Amplification and Mesh shaders for determining the index of a thread's wave within a thread group.