### PR TITLE
Increase Group Shared Memory Limit

### DIFF
--- a/proposals/0049-variable-groupshared-memory.md
+++ b/proposals/0049-variable-groupshared-memory.md
@@ -1,5 +1,5 @@
 ---
-title: "NNNN - Variable Group Shared Memory"
+title: "0049 - Variable Group Shared Memory"
 params:
   authors:
   - jackell: Jack Elliott


### PR DESCRIPTION
Proposes a mechanism to replace the static limit of 32kb of group shared memory for Compute, Mesh and Amplification shaders with a variable limit to allow implementations to expose larger sizes of local memory.