### PR TITLE
Add agenda and minutes for 2025-11-11 meeting

### DIFF
--- a/docs/DesignMeetingMinutes/2025-11-11.md
+++ b/docs/DesignMeetingMinutes/2025-11-11.md
@@ -42,14 +42,40 @@ title: "Design Meeting Minutes: 2025/11/11"
 
 * Needs Review
   * [Unsized arrays](https://github.com/microsoft/hlsl-specs/pull/634)
+    * @sspall to review
   * [Matrix Accessors](https://github.com/microsoft/hlsl-specs/pull/678)
+    * @V-FEXrt to review
   * [[0002] Detail attributes that will replace HLSL annotations](https://github.com/microsoft/hlsl-specs/pull/534)
+    * @hekota to review
+* Call to accept
+  * [[0037] - Cbuffer contexts](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0037-cbuffer-contexts.md)
+    * Need reviewers for [language spec](https://github.com/microsoft/hlsl-specs/pull/684)
+      * @bogner & @hekota
+* Review in-flight proposals
+  * State updates:
+    * **Under Review** [Numeric constants](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0003-numeric-constants.md)
+      * Move to **Under Consideration**, this doesn't have a full spec and really isn't ready to be under review.
+    * **Under Review** [202x Deprecations](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0036-202x-deprecations.md)
+      * Move to **Accepted**
+      * We should aim to get deprecation warnings into DXC soon
+    * [`cbuffer` Contexts](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0037-cbuffer-contexts.md)
+      * Move to **Accepted**
+    * **Under Review** [`hlsl` namespace](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0001-hlsl-namespace.md)
+      * Move to **Accepted** (still need to evaluate for 202x)
+    * **Under Review** [C++ 11 base](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0023-cxx11-base.md)
+      * Move to **Under Consideration**, this doesn't have a full spec and really isn't ready to be under review.
+  * Work to do
+    * [`groupshared` arguments](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0043-groupshared-arguments.md)
+      * @damyanp & @llvm-beanz to figure out finalizing this spec
+* Next Meeting
+  * Groupshared arguments
+  * Unbound arrays
+  * C++ attributes
+* Process Discussion
+  * We should be more speedy at merging new proposals (this has come up many times)
+  * We should consider disabling the "require resolving comments" feature in GitHub to make it easier to merge
   
 #### Discussion Topics
-
-* [[0037] - Cbuffer contexts](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0037-cbuffer-contexts.md)
-  * Call to accept
-  * Need reviewers for [language spec](https://github.com/microsoft/hlsl-specs/pull/684)
 
 
 ## Other Discussion


### PR DESCRIPTION
This adds the agenda and meeting minutes doc for the 2025-11-11 design meeting.