### PR TITLE
Add agenda and meeting minutes for 2025-11-25

### DIFF
--- a/docs/DesignMeetingMinutes/2025-11-25.md
+++ b/docs/DesignMeetingMinutes/2025-11-25.md
@@ -42,10 +42,22 @@ title: "Design Meeting Minutes: 2025/11/25"
 ### Current Business
 
 * Needs Review
+  * [bitfields spec language](https://github.com/microsoft/hlsl-specs/pull/743)
+    * Action item: @llvm-beanz & @imbelic to review
 * Call to accept
   * [C++ Attributes](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0002-cxx-attributes.md)
+    * There was some discussion about the attribute syntax for bindings. In particular the current proposal's text would deprecate applying resource bindings on user-defined types and having the binding apply to the members.
+    * Action Item: @llvm-beanz to update proposal to clarify that specific attributes are not final.
+    * Accepted by overall consensus.
   * [Restricted Unbounded Arrays](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0042-restricted-unbounded-arrays.md)
+    * Accepted by overall consensus.
   * [`groupshared` arguments](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0043-groupshared-arguments.md)
+    * One point of discussion was around the `[noinline]` attribute.
+      * There is a desire that this work in the future.
+      * The current implementation in DXC is quite hacky.
+      * @llvm-beanz and @tex3d agreed that this is unlikely to be a standardizable feature since it doesn't work across APIs and likely needs changes to DXIL and SPIRV for accurate code generation.
+    * Action Item: @spall to update with overloading semantics.
+    * Accepted by overall consensus.
 
 #### Discussion Topics
 


### PR DESCRIPTION
This adds the meeting minutes and agenda for the 2025-11-25 language design meeting.