### PR TITLE
[0045] Clustered Geometry:  Add ALLOW_CLUSTERED_GEOMETRY flag to raytracing pipeline state and RAYQUERY_FLAGS

### DIFF
--- a/proposals/0045-clustered-geometry.md
+++ b/proposals/0045-clustered-geometry.md
@@ -4,6 +4,7 @@ params:
   authors:
   - jschmid-nvidia: Jan Schmid
   - simoll: Simon Moll
+  - amarpMSFT: Amar Patel
   sponsors:
   - jenatali: Jesse Natalie
   status: Under Review


### PR DESCRIPTION
Pasting relevant text from motivation section in the spec:

> There also needs to be a way for apps to tell driver shader compilation to expect that 
acceleration structures being raytraced may contain clusters.  In the API this is a 
raytracing pipeline flag, `D3D12_RAYTRACING_PIPELINE_FLAG_ALLOW_CLUSTERED_GEOMETRY`. 
This flag needs to be available when raytracing pipeline state subobjects are 
authored in HLSL, including `RayQuery` objects for inline raytracing.
>
> The reason for the flag is if possibility of clusters in an acceleration structure requires 
a different path in the driver/hardware ray traversal algorithm.  This path might add 
overhead that can be avoided if it is known clusters will not be used.  In other words, 
a driver that supports clustered geometry should not regress the performance of applications 
that choose not to use it, or shipped before clustered geometry existed.

This addition builds on similar HLSL/DXIL functionality that was needed for Opacity Micromaps.  See https://github.com/microsoft/hlsl-specs/blob/main/proposals/0024-opacity-micromaps.md.  
So this time around it is easier to make the addition.