### PR TITLE
Update 0026-hlsl-long-vector-type.md

### DIFF
--- a/proposals/0026-hlsl-long-vector-type.md
+++ b/proposals/0026-hlsl-long-vector-type.md
@@ -131,8 +131,8 @@ in undefined behavior.
 
 StructuredBuffers with N-element vectors are declared using the template syntax
  with a long vector type as the template parameter.
-N-element vectors are loaded and stored from StructuredBuffers using the non-templated load and store methods
-with the element index parameters.
+N-element vectors are loaded and stored from StructuredBuffers using the load and store methods
+or subscript operators with the element index parameters.
 
 ```hlsl
 RWStructuredBuffer< vector<T, N> > myBuffer;


### PR DESCRIPTION
The 2nd part is for StructuredBuffers instead of for ByteAddressBuffers.