### PR TITLE
[Spec][Matrix] Define Matrix truncation in the Standard Conversion Sequences and map to Conv.vtrunc

### DIFF
--- a/specs/language/overloading.tex
+++ b/specs/language/overloading.tex
@@ -301,6 +301,15 @@ below:
 
     Vector truncation conversion & Dimensionality Reduction Conversion
           & Conversion Truncation & \ref{Conv.vtrunc} \\ \cline{1-4}
+
+    Matrix truncation (without conversion) & Dimensionality Reduction
+          & Truncation & \ref{Conv.vtrunc} \\ \cline{1-4}
+
+    Matrix truncation promotion & Dimensionality Reduction Promotion
+          & Promotion Truncation & \ref{Conv.vtrunc} \\ \cline{1-4}
+
+    Matrix truncation conversion & Dimensionality Reduction Conversion
+          & Conversion Truncation & \ref{Conv.vtrunc} \\ \cline{1-4}
     \hline
   \end{tabular}
 \end{center}


### PR DESCRIPTION
fixes #746

Conv.vtrunc already defined the matrix trunc behavior. All that is needed is for the Standard Conversion Sequences table to point to the matrix trunc conversion to the right place.