### PR TITLE
[0035] Revise createMatrix to create a unique reference

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1009,10 +1009,14 @@ represents other attributes of the created matrix.
 ```llvm
 declare %dx.types.MatrixRef @dx.op.createMatrix(
   immarg i32  ; opcode
+  %dx.types.MatrixRef *,       ; Alloca representing the unique matrix
   )
 ```
 
-Creates a new uninitialized matrix handle.
+Creates a new matrix handle referencing the global or local alloca that uniquely
+represents the matrix. Create calls for globals are found in the entry block of
+the entry function. This handle is to be used by all other operations taking a
+MatrixRef argument. There should only be one create call for each unique matrix.
 
 ```llvm
 declare %dx.types.MatrixRef @dx.op.annotateMatrix(
@@ -1023,7 +1027,8 @@ declare %dx.types.MatrixRef @dx.op.annotateMatrix(
 ```
 
 Defines a matrix as having the specified component type, dimensions, use, and
-scope.
+scope. Global, local, and parameter matrices should be annotated to provide
+this type information in the local scope.
 
 ```llvm
 declare @dx.op.fillMatrix.[TY](


### PR DESCRIPTION
After losing all its type information to annotateMatrix, createMatrix had no purpose and would have resulted in all calls being merged as redundant, however, some means of uniquely identifying a matrix is needed that annotateMatrix can't do because it needs to be generated for parameters as well as locals and globals (assuming we allow globals).

Previous handles for resources have had global variables that are able to uniquely identify them and workgraph handles have had parameters to the entry functions. Lacking either of these, it was impossible to distinguish allocas created for the initial declaration of a matrix and one that was created for a parameter that should get merged when inlining that function. By generating a unique createMatrix call where the local variable is declared or in the entry block for global variables.

Addresses some issues in #696 though not in the way I initially proposed there