### PR TITLE
[Matrix] Reorganize into its own splat section

### DIFF
--- a/specs/language/conversions.tex
+++ b/specs/language/conversions.tex
@@ -150,14 +150,15 @@ type \texttt{T[M]}, if \texttt{N} is greater than or equal to \texttt{M}.
 prvalue of type \texttt{vector<T,x>}. The destination value is the source value
 replicated into each element of the destination.
 
+\p A prvalue of type \texttt{vector<T,1>} can be converted
+to a prvalue of type \texttt{vector<T,x>}. The destination value is the value in
+the source vector replicated into each element of the destination.
+
+\Sec{Matrix splat conversion}{Conv.msplat}
 \p A glvalue of type \texttt{T} can be converted to a cxvalue of type
 \texttt{matrix<T,x,y>} or a prvalue of type \texttt{T} can be converted to a
 prvalue of type \texttt{matrix<T,x,y>}. The destination value is the source
 value replicated into each element of the destination.
-
-\p A prvalue of type \texttt{vector<T,1>} can be converted
-to a prvalue of type \texttt{vector<T,x>}. The destination value is the value in
-the source vector replicated into each element of the destination.
 
 \Sec{Array and Class splat conversion}{Conv.asplat}
 

--- a/specs/language/overloading.tex
+++ b/specs/language/overloading.tex
@@ -271,8 +271,11 @@ below:
           & \ref{Conv.array} \\ \cline{1-2}\cline{4-4}
     Qualification & Qualification Adjustment & & \ref{Conv.qual} \\ \cline{1-4}
 
-    Scalar splat (without conversion) & Scalar Extension & Extension
-          & \ref{Conv.vsplat} \\ \cline{1-4}
+    Vector Scalar splat conversion & Scalar Extension Conversion & Conversion Extension
+      & \ref{Conv.vsplat} \\ \cline{1-4}
+
+    Matrix Scalar splat conversion & Scalar Extension Conversion & Conversion Extension
+          & \ref{Conv.msplat} \\ \cline{1-4}
 
     Integral promotion & &
           & \ref{Conv.iconv} \& \ref{Conv.rank.int} \\ \cline{1-1}\cline{4-4}


### PR DESCRIPTION
fixes #753

Before this change overloading.tex refered to both Matrix and Vector splats as Scalar splat but Conversions.tex  had these both under Vector splat conversion. This created a bit of ambiguity that could be fixed up by just organizing them into their own sections.

The new layout:
<img width="1322" height="720" alt="image" src="https://github.com/user-attachments/assets/aa9a776f-9d4e-472f-b885-b03ab7a5d6c9" />
<img width="1290" height="432" alt="image" src="https://github.com/user-attachments/assets/839ec366-32c1-4709-a0ff-5b1b527628b0" />
