### PR TITLE
[0035] Address a swath of feedback

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1203,7 +1203,7 @@ The validator will ensure that the group shared target memory is large enough
 for the write.
 
 ```llvm
-declare i32 @dx.op.matrixQueryAccumulatorLayout.v[NUM][TY](
+declare i32 @dx.op.matrixQueryAccumulatorLayout(
   immarg i32,            ; opcode
   )
 ```
@@ -1215,7 +1215,7 @@ layout while a return value of `1` will denote that accumulator matrices are `B`
 layout.
 
 ```llvm
-declare void @dx.op.matrixOp(
+declare void @dx.op.matrixMulOp(
   immarg i32,            ; opcode
   %dx.types.MatrixRef,   ; matrix A
   %dx.types.MatrixRef,   ; matrix B
@@ -1241,7 +1241,7 @@ Must be called from wave-uniform control flow.
 
 
 ```llvm
-declare void @dx.op.matrixBinOp(
+declare void @dx.op.matrixAccumulate(
   immarg i32,            ; opcode
   %dx.types.MatrixRef,   ; matrix RHS
   %dx.types.MatrixRef,   ; matrix LHS
@@ -1409,7 +1409,7 @@ struct MatrixUse {
 ```
 
 This object will encode each matrix shape and element type as used by the DXIL
-operations in the `matrixOp` and `matvecmuladd` opcode classes.
+operations in the `matrixMulOp` and `matvecmuladd` opcode classes.
 
 The Scope field will encode one of the values defined in the [`DXILMatrixScope`
 enumeration](#dxil-enumerations).


### PR DESCRIPTION
This PR folds in a bunch of changes to address feedback that has been backed up. One big change is the removal of `annotateMatrix` in favor of type mangling. Using type mangling reduces the need for the compiler to emit and de-duplicate `annotateMatrix` calls, and aligns more closely to how we'll support this in modern LLVM using target extension types. This is a first step to addressing matrix lifetime issues.

* Mangle matrix attributes into `AttributedMatrixRef`
* Added transpose compile-time argument to `cast` (Resolves #653).
* Renamed `Accumulate` operations that operate on memory to `InterlockedAccumulate`, and clarify atomicity (Resolves #744).
* Replaced `SumAccumulate` with new `Accumulate` on A and B matrices (Resolves #755, Resolves #618).
* Layout for `Matrix::Load` on thread-scope matrices is now compile-time constant (Resolves #681).
* `InterlockedAccumulate` for thead-scope matrices no longer takes a layout parameter since it must be OuterProductOptimal.
* Added clarification of matrix stage availability (Resolves #574).
* Fixed the form of the outerProduct DXIL op to not create a matrix (Resolves #696).
* Clarify `Stride` parameters (partial feedback from #581).