### PR TITLE
Update proposal status per design meeting

### DIFF
--- a/proposals/0002-cxx-attributes.md
+++ b/proposals/0002-cxx-attributes.md
@@ -5,10 +5,8 @@ params:
   - llvm-beanz: Chris Bieneman
   sponsors:
   - llvm-beanz: Chris Bieneman
-  status: Under Review
+  status: Accepted
 ---
-
-
 
 * Planned Version: 202y
 

--- a/proposals/0042-restricted-unbounded-arrays.md
+++ b/proposals/0042-restricted-unbounded-arrays.md
@@ -5,7 +5,7 @@ params:
     - llvm-beanz: Chris Bieneman
   sponsors:
     - llvm-beanz: Chris Bieneman
-  status: Under Review
+  status: Accepted
 ---
 
 * Planned Version: 202x

--- a/proposals/0043-groupshared-arguments.md
+++ b/proposals/0043-groupshared-arguments.md
@@ -6,7 +6,7 @@ params:
     - spall: Sarah Spall
   sponsors:
     - spall: Sarah Spall
-  status: Under Review
+  status: Accepted
 ---
 
 * Planned Version: 202x


### PR DESCRIPTION
This is just catching up on updating proposal status as per the 2025-11-25 design meeting. See minutes in #726.