### PR TITLE
[0035] Rework specification to treat matrices as values

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1159,7 +1159,7 @@ If the index is out of range for the values stored in this thread the result is
 0.
 
 ```llvm
-declare %dx.types.LinAlgMatrix<mangling> @dx.op.matrixSetElement.[MatTy].[Ty](
+declare %dx.types.LinAlgMatrix<mangling> @dx.op.matrixSetElement.[MatTy].[MatTy].[Ty](
   immarg i32,                         ; opcode
   %dx.types.LinAlgMatrix<mangling>,   ; input matrix
   i32,                                ; thread-local index


### PR DESCRIPTION
This updates the linalg spec to treat the AttributedMatrixRef objects as value objects in the SSA graph. This should address concerns about object lifetimes.

Fixes #756