### PR TITLE
[0053] Allow Early Pixel Culling

### DIFF
--- a/proposals/0053-allow-early-pixel-culling.md
+++ b/proposals/0053-allow-early-pixel-culling.md
@@ -1,6 +1,5 @@
 ---
-title: "NNNN - Allow Early Pixel Culling"
-draft: true
+title: "0053 - Allow Early Pixel Culling"
 params:
   authors:
     - mapodaca-nv: Mike Apodaca


### PR DESCRIPTION
This proposal introduces a new `[allowearlypixelculling]` attribute for HLSL
Pixel Shaders that enables implementations to perform early pixel culling
optimizations for shaders with side effects.