### PR TITLE
Add agenda and minutes for 2026/01/20

### DIFF
--- a/docs/DesignMeetingMinutes/2026-01-20.md
+++ b/docs/DesignMeetingMinutes/2026-01-20.md
@@ -14,6 +14,9 @@ title: "Design Meeting Minutes: 2026/01/26"
 
 ## Administrivia
 * Meeting format changes!
+  * TL;DR - This meeting is going away after today.
+  * New meetings will be conducted under a new more friendly IP structure. If you have questions please reach out.
+  * Action Item: @llvm-beanz working to wrap up language spec PRs before the end of the month.
 
 ## Issues
 * No marked issues
@@ -41,12 +44,16 @@ title: "Design Meeting Minutes: 2026/01/26"
 
 * Updates
   * [bitfields spec language](https://github.com/microsoft/hlsl-specs/pull/743)
-    * Ready to merge!
+    * Not actually ready to merge.
+    * Action Item: @llvm-beanz and @spall to follow-up.
   * [C++ Attributes](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0002-cxx-attributes.md)
     * [Follow-up from 2025/11/25](https://github.com/microsoft/hlsl-specs/pull/775)
+      * Action Item: @bogner & @hekota to review
   * [[dxil] Proposal to add new debug printf dxil op](https://github.com/microsoft/hlsl-specs/pull/324)
     * @tex3d will review this in more detail.
     * @llvm-beanz [prototyped alternative approach](https://www.abolishcrlf.org/2025/12/31/Printf.html)
+      * Action Item: @llvm-beanz to write up a proposal.
+* Short meeting today: meeting adjourned after 15 minutes.
 
 #### Discussion Topics
 


### PR DESCRIPTION
This PR adds agenda and meeting minute information for the 2026/01/20 HLSL public design meeting.