### PR TITLE
Update some notes in long vector test plan

### DIFF
--- a/proposals/infra/INF-0006-Long-Vector-ExecutionTest-Plan.md
+++ b/proposals/infra/INF-0006-Long-Vector-ExecutionTest-Plan.md
@@ -223,7 +223,7 @@ Operator table from [Microsoft HLSL Operators](https://learn.microsoft.com/en-us
 | ✅ | Bitwise Operators | ~, <<, >>, &, \|, ^, | Only valid on int and uint vectors |
 | ☑️ | Bitwise Assignment Operators | <<=, >>=, &=, \|=, ^= | Only valid on int and uint vectors |
 | ✅ | Boolean Math Operators | & &, \|\| , ?: | |
-| ✅ | Cast Operator | (type) | No direct operator, difference in GetElementPointer  or load type |
+| ✅ | Cast Operator | (type) | No direct operator, difference in GetElementPointer or load type |
 | ✅ | Comparison Operators | <, >, ==, !=, <=, >= | |
 | ☑️ | Prefix or Postfix Operators | ++, -- | |
 | ☑️ | Unary Operators | !, -, + | |


### PR DESCRIPTION
Update table in long vector exec test plan to reflect tests that were explicitly omitted due to already having coverage via other tests. For example, the '+=' isn't special and already has coverage via '+' and '=' tests.