### PR TITLE
[0035] Specify a way to transpose Thread Scope matrices on load and constraint loads to A-type Matrices.

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1660,7 +1660,7 @@ in the [`DXIL::ComponentType` enumeration](#dxil-enumerations).
 
 ## Appendix 1: HLSL Header
 
-[Compiler Explorer](https://godbolt.org/z/d3dsczPMj)
+[Compiler Explorer](https://godbolt.org/z/dGrfY1T69)
 > Note: this mostly works with Clang, but has some issues to work out still.
 
 ```cpp


### PR DESCRIPTION
This PR fixes [PR#787](https://github.com/microsoft/hlsl-specs/issues/787).
Changes:
1. Extends the `MatrixLayoutEnum` to contain Transpose types that specify that the matrices will be transposed on load. This applies only to Thread scope optimal layout matrices. InterlockedAccumulate will continue to support only `OuterProductOptimal` layout for thread scope matrix, and not the transpose variant.
2. Also, we were missing a restriction on the Thread scope matrix loads, that they are only useful for A-type matrices as the only user of these loads are the Multiply(Matrix,Vector)/MultiplyAdd(Matrix,Vector) operations which only accept A Matrices. That constraint is added as well.