### PR TITLE
HTML generation: two small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A listing of the active proposals is available [here](proposals/).
 
 This repository also contains specifications for the HLSL language. The draft
 HLSL specification is available in
-[HTML](https://microsoft.github.io/hlsl-specs/specs/hlsl.html) and
+[HTML](https://microsoft.github.io/hlsl-specs/specs/index.html) and
 [PDF](https://microsoft.github.io/hlsl-specs/specs/hlsl.pdf).
 
 ## Contributing

--- a/specs/language/template.html
+++ b/specs/language/template.html
@@ -23,7 +23,7 @@ $endif$
 
 <a href="$top.url$" accesskey="t" rel="top">
 <img
-  src="resources/HLSL.png"
+  src="https://microsoft.github.io/hlsl-specs/resources/HLSL.png"
   class="logo"
   width="128"
 />


### PR DESCRIPTION
This fixes the readme to link correctly to the index, and uses an absolute URL for the logo since it gets put one directory up in the hierarchy for the final site.