### PR TITLE
[0035] Restrict OuterProduct to thread scope

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -425,7 +425,7 @@ The following table summarizes the operations supported for each matrix scope:
 | `linalg::Multiply(Matrix, Matrix)` | ✗ | ✓ | ✓ |
 | `linalg::Multiply(vector, Matrix)` | ✓ | ✗ | ✗ |
 | `linalg::MultiplyAdd(Matrix, vector, vector)` | ✓ | ✗ | ✗ |
-| `linalg::OuterProduct(vector, vector)` | ✓ | ✓ | ✓ |
+| `linalg::OuterProduct(vector, vector)` | ✓ | ✗ | ✗ |
 
 Throughout this document a matrix may be described as having a scope as
 specified by the `Scope` parameter (e.g. a matrix with `Scope == Thread` is a
@@ -944,18 +944,16 @@ vector.
 #### linalg::OuterProduct(vector, vector)
 
 ```c++
-template <ComponentType OutTy, MatrixScope Scope, typename InputElTy,
+template <ComponentType OutTy, typename InputElTy,
           uint M, uint N>
-Matrix<OutTy, M, N, MatrixUse::Accumulator, Scope>
+Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::Thread>
     linalg::OuterProduct(vector<InputElTy, M>, vector<InputElTy, N>);
 ```
 
-The `linalg::OuterProduct` function has two overloads that take an M-element vector
-and an N-element vector and yield an MxN `Accumulator` matrix with the specified
-scope initialized with the outer product of the two input vectors. One overload
-infers the type of the output accumulator to match the input vector element type,
-the other overload takes a template parameter for the output matrix element type.
-All matrix scopes are allowed for the output matrix.
+The `linalg::OuterProduct` function takes an M-element vector and an N-element
+vector and yield an MxN `Accumulator` matrix with `Thread` scope initialized
+with the outer product of the two input vectors. The function takes a template
+parameter for the output matrix element type.
 
 #### linalg::MultiplyAdd(Matrix, vector, vector)
 
@@ -1380,7 +1378,7 @@ declare %dx.types.LinAlgMatrix<mangling> @dx.op.linAlgMatrixOuterProduct.[MatTy]
 ```
 
 Writes the outer product of the two input vectors into the provided matrix.
-The matrix scope can be `Thread`, `Wave`, or `ThreadGroup`.
+The matrix scope must be `Thread`.
 
 Validation will ensure that:
 * The `M` dimension of the matrix matches the length of vector `A`, or 1/4th the
@@ -1391,6 +1389,7 @@ Validation will ensure that:
   vectors, or the input vectors are `i32` if the matrix uses types not directly
   representable in DXIL.
 * The element type of vector A and vector B must be the same.
+* The matrix output type must be `Thread` scope.
 
 #### Bounds Checking Behavior
 


### PR DESCRIPTION
This addresses the feedback in #785.

Fixes #785.