### PR TITLE
INF-0006: Note that packed data types don't need HLK coverage

### DIFF
--- a/proposals/infra/INF-0006-Long-Vector-ExecutionTest-Plan.md
+++ b/proposals/infra/INF-0006-Long-Vector-ExecutionTest-Plan.md
@@ -92,7 +92,14 @@ We break coverage down into five test categories.
 Testing will cover the following vector element data types:
 
 * bool, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float16_t,
-float32_t, float64_t, packed_int16_t, and packed_uint16_t.
+float32_t, and float64_t.
+
+**Note on packed data types:** `packed_int16_t` and `packed_uint16_t` do not
+require HLK coverage. Although tests for these types were originally planned
+(see [DXC issue #7683](https://github.com/microsoft/DirectXShaderCompiler/issues/7683)),
+we determined that DXIL represents packed data types as 32-bit types. Because
+no distinct DXIL-level behavior exists for them, dedicated HLK coverage is
+unnecessary.
 
 ## Vector sizes and alignments to test
 


### PR DESCRIPTION
Remove packed_int16_t and packed_uint16_t from the "Vector element data types to test" list (coverage explained in the note added previously)