### PR TITLE
LinAlg spec update - add SFINAE restrictions, argument names, clarify matrix use

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -150,7 +150,7 @@ class Matrix {
                         uint Align = sizeof(ElementType));
 
   template <typename T, MatrixUseEnum UseLocal = Use,
-            MatrixScopeEnum ScopeLocal = Scope, SIZE_T Size>
+            MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
   typename hlsl::enable_if<
       hlsl::is_arithmetic<T>::value && Use == MatrixUse::Accumulator &&
           UseLocal == Use && (M * N / ElementsPerScalar <= Size) &&
@@ -943,7 +943,7 @@ Matrix::InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
                               uint Align = sizeof(ElementType));
 
 template <typename T, MatrixUseEnum UseLocal = Use, 
-          MatrixScopeEnum ScopeLocal = Scope, SIZE_T Size>
+          MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
 typename hlsl::enable_if<
       hlsl::is_arithmetic<T>::value && Use == MatrixUse::Accumulator &&
           UseLocal == Use && (M * N / ElementsPerScalar <= Size) &&
@@ -1678,7 +1678,7 @@ in the [`DXIL::ComponentType` enumeration](#dxil-enumerations).
 
 ## Appendix 1: HLSL Header
 
-[Compiler Explorer](https://godbolt.org/z/dGrfY1T69)
+[Compiler Explorer](https://godbolt.org/z/Peh4jxrx3)
 > Note: this mostly works with Clang, but has some issues to work out still.
 
 ```cpp
@@ -1949,7 +1949,7 @@ class Matrix {
                         uint Align = sizeof(ElementType));
 
   template <typename T, MatrixUseEnum UseLocal = Use,
-            MatrixScopeEnum ScopeLocal = Scope, SIZE_T Size>
+            MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
   typename hlsl::enable_if<
       hlsl::is_arithmetic<T>::value && Use == MatrixUse::Accumulator &&
           UseLocal == Use && (M * N / ElementsPerScalar <= Size) &&


### PR DESCRIPTION
- Add SFINAE restrictions:
  - thread-scope `Matrix::Load` to require `A` matrix
  - thread-scope `Matrix::InterlockedAccumulate` to require `Accumulator` matrix
  - groupshared `Matrix::InterlockedAccumulate` to require `Wave` scope
  - `Multiply*` for matrix and vector to require arithmetic type
  - `Size` template parameter to groupshared `Matrix::Load` and `Matrix::InterlockedAccumulate`
- Add argument names to functions that were missing them. Some of the functions already had named arguments, so this is done for consistency. There were also cases where a function description was referring to an argument by name and the function declaration did not have it named.
- Fix array size condition on `Matrix::Store`
- Update Vector-Matrix operations to be Matrix `A` only