### PR TITLE
[0035] Add Soft FP8 types to allow emulation

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1192,7 +1192,7 @@ of the valid linalg component types listed below:
 #### SoftF8 Types
 
 The new `SoftF8` types are fp8 in memory, but allow a driver to up-convert to
-higher precision types (generally fp16) for exectuion. These types are only
+higher precision types (generally fp16) for execution. These types are only
 valid as component types for thread scope matrices.
 
 #### Type Metadata


### PR DESCRIPTION
This adds two new Enum values for FP8 types for allowing software-emulation (at equal or higher precision) of FP8 types if the underlying hardware does not support the FP8 format requested.