### PR TITLE
[0035] Restrict Wave and ThreadGroup scope to compute stage

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -394,8 +394,8 @@ and how a matrix can be used.
 ### Stage Availability
 
 All operations on `Thread` scope matrices are available in all shader stages.
-Operations on `Wave` and `ThreadGroup` scope matrices are available in compute,
-mesh, and amplification shaders.
+Operations on `Wave` and `ThreadGroup` scope matrices are available in compute
+shaders.
 
 #### Matrix Use
 


### PR DESCRIPTION
We've encountered some difficulties that make larger changes required to support Wave and ThreadGroup scope matrices in Mesh and Amplification shaders. To avoid increasing the complexity for the preview release we're removing that support.

We may revisit this before the final release.

Resolves #840.