### PR TITLE
[0035] LinAlg: Remove Align from thread scope InterlockedAccumulate

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -199,8 +199,7 @@ class Matrix<ComponentTy, M, N, Use, MatrixScope::Thread> {
   template <MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
-  InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
-                        uint Align = sizeof(ElementType));
+  InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset);
 };
 
 MatrixUseEnum AccumulatorLayout();
@@ -376,7 +375,7 @@ void OuterProdAccum() {
   MatrixAccumTy MatAcc =
       OuterProduct<ComponentType::F16>(VecA, VecB);
 
-  MatAcc.InterlockedAccumulate(Buf, 0, 0, MatrixLayout::OuterProductOptimal);
+  MatAcc.InterlockedAccumulate(Buf, 0);
 }
 ```
 
@@ -976,8 +975,7 @@ Matrix::InterlockedAccumulate(/*groupshared*/ T Arr[Size], uint StartIdx,
 template <MatrixUseEnum UseLocal = Use>
 typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                          void>::type
-Matrix::InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
-                                   uint Align = sizeof(ElementType));
+Matrix::InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset);
 ```
 
 Matrices with `Wave` and `ThreadGroup` scope support a `Layout` parameter which
@@ -2068,8 +2066,7 @@ class Matrix<ComponentTy, M, N, Use, MatrixScope::Thread> {
   template <MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
-  InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
-                        uint Align = sizeof(ElementType));
+  InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset);
 };
 
 MatrixUseEnum AccumulatorLayout();


### PR DESCRIPTION
There's no need for Align parameter in thread-scope InterlockedAccumulate since the layout must be OuterProductOptimal, and alignment requirement will be device-dependent.

Also fixed an example use case, missed in the prior change that removed Stride and Layout parameters.

Fixes #851