### PR TITLE
[0035] Always set align to 128

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -105,10 +105,10 @@ class Matrix {
   Splat(T Val);
 
   static Matrix Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
-                     MatrixLayoutEnum Layout, uint Align = sizeof(ElementType));
+                     MatrixLayoutEnum Layout, uint Align = 128);
 
   static Matrix Load(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
-                     MatrixLayoutEnum Layout, uint Align = sizeof(ElementType));
+                     MatrixLayoutEnum Layout, uint Align = 128);
 
   template <typename T, SIZE_TYPE Size>
   static typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
@@ -138,7 +138,7 @@ class Matrix {
   Set(uint Index, ElementType Value);
 
   void Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
-             MatrixLayoutEnum Layout, uint Align = sizeof(ElementType));
+             MatrixLayoutEnum Layout, uint Align = 128);
 
   template <typename T, SIZE_TYPE Size>
   typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
@@ -153,7 +153,7 @@ class Matrix {
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                         MatrixLayoutEnum Layout,
-                        uint Align = sizeof(ElementType));
+                        uint Align = 128);
 
   template <typename T, MatrixUseEnum UseLocal = Use,
             MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
@@ -194,13 +194,13 @@ class Matrix<ComponentTy, M, N, Use, MatrixScope::Thread> {
   static typename hlsl::enable_if<Use == MatrixUse::A && UseLocal == Use,
                                   Matrix>::type
   Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
-       uint Align = sizeof(ElementType));
+       uint Align = 128);
 
   template <MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
-                        uint Align = sizeof(ElementType));
+                        uint Align = 128);
 };
 
 MatrixUseEnum AccumulatorLayout();
@@ -793,12 +793,12 @@ Matrix::Splat(WaveReadLaneFirst(Val));
 ```c++
 static Matrix Matrix::Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
                            MatrixLayoutEnum Layout,
-                           uint Align = sizeof(ElementType));
+                           uint Align = 128);
 
 // Not available on Thread scope matrices.
 static Matrix Matrix::Load(RWByteAddressBuffer Res, uint StartOffset,
                            uint Stride, MatrixLayoutEnum Layout,
-                           uint Align = sizeof(ElementType));
+                           uint Align = 128);
 
 // Not available on Thread scope matrices.
 template <typename T, SIZE_TYPE Size>
@@ -917,7 +917,7 @@ then the operation is a no-op.
 ```c++
 void Matrix::Store(
     RWByteAddressBuffer Res, uint StartOffset, uint Stride, MatrixLayout Layout,
-    uint Align = sizeof(__detail::ComponentTypeTraits<ComponentTy>::Type));
+    uint Align = 128);
 
 template <typename T, SIZE_TYPE Size>
 typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
@@ -960,7 +960,7 @@ typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                          void>::type
 Matrix::InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
                               uint Stride, MatrixLayoutEnum Layout,
-                              uint Align = sizeof(ElementType));
+                              uint Align = 128);
 
 template <typename T, MatrixUseEnum UseLocal = Use,
           MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
@@ -977,7 +977,7 @@ template <MatrixUseEnum UseLocal = Use>
 typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                          void>::type
 Matrix::InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
-                                   uint Align = sizeof(ElementType));
+                                   uint Align = 128);
 ```
 
 Matrices with `Wave` and `ThreadGroup` scope support a `Layout` parameter which
@@ -1974,10 +1974,10 @@ class Matrix {
   Splat(T Val);
 
   static Matrix Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
-                     MatrixLayoutEnum Layout, uint Align = sizeof(ElementType));
+                     MatrixLayoutEnum Layout, uint Align = 128);
 
   static Matrix Load(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
-                     MatrixLayoutEnum Layout, uint Align = sizeof(ElementType));
+                     MatrixLayoutEnum Layout, uint Align = 128);
 
   template <typename T, SIZE_TYPE Size>
   static typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
@@ -2007,7 +2007,7 @@ class Matrix {
   Set(uint Index, ElementType Value);
 
   void Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
-             MatrixLayoutEnum Layout, uint Align = sizeof(ElementType));
+             MatrixLayoutEnum Layout, uint Align = 128);
 
   template <typename T, SIZE_TYPE Size>
   typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
@@ -2022,7 +2022,7 @@ class Matrix {
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                         MatrixLayoutEnum Layout,
-                        uint Align = sizeof(ElementType));
+                        uint Align = 128);
 
   template <typename T, MatrixUseEnum UseLocal = Use,
             MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
@@ -2063,13 +2063,13 @@ class Matrix<ComponentTy, M, N, Use, MatrixScope::Thread> {
   static typename hlsl::enable_if<Use == MatrixUse::A && UseLocal == Use,
                                   Matrix>::type
   Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
-       uint Align = sizeof(ElementType));
+       uint Align = 128);
 
   template <MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
-                        uint Align = sizeof(ElementType));
+                        uint Align = 128);
 };
 
 MatrixUseEnum AccumulatorLayout();


### PR DESCRIPTION
The minimum common alignment is 128 and internal discussion landed on that also likely being the largest useful value.

At least for preview, always set that value in the header. We can reevaluate in the future but we are leaning on not changing the DXIL op so the value can be easily updated.