### PR TITLE
[0035] Add description of `__detail` structs and update `DstN` calculations

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -716,7 +716,8 @@ __MATRIX_SCALAR_COMPONENT_MAPPING(ComponentType::F64, double)
 
 template <ComponentEnum DstTy, ComponentEnum SrcTy, int SrcN> struct DstN {
   static const int Value =
-      (SrcN * ComponentTypeTraits<SrcTy>::ElementsPerScalar) /
+      (SrcN * ComponentTypeTraits<SrcTy>::ElementsPerScalar +
+       ComponentTypeTraits<DstTy>::ElementsPerScalar - 1) /
       ComponentTypeTraits<DstTy>::ElementsPerScalar;
 };
 
@@ -737,6 +738,18 @@ The `linalg::__detail::ComponentTypeTraits` struct is provided as an
 implementation detail to enable mapping `ComponentType` values to their
 native HLSL element types and differentiating between types that have native
 scalar support.
+
+The `linalg::__detail::DstN` struct computes the destination vector size when
+converting between two different component types. `Value` is calculated as the
+number of source vector elements (`SrcN`) multiplied by the source type's
+`ElementsPerScalar`, divided by the destination type's `ElementsPerScalar`,
+rounded up to the nearest integer.
+
+The `linalg::__detail::DimMN` struct conditionally swaps the `M` and `N`
+dimension values based on the `Transposed` parameter. When `false`, `M` and `N`
+are passed through unchanged. When `Transposed` is `true`, `M` and `N` are
+swapped. This is used by `Matrix::Cast` to compute the dimensions of a
+transposed matrix.
 
 #### linalg::Convert
 
@@ -1907,7 +1920,8 @@ __MATRIX_SCALAR_COMPONENT_MAPPING(ComponentType::F64, double)
 
 template <ComponentEnum DstTy, ComponentEnum SrcTy, int SrcN> struct DstN {
   static const int Value =
-      (SrcN * ComponentTypeTraits<SrcTy>::ElementsPerScalar) /
+      (SrcN * ComponentTypeTraits<SrcTy>::ElementsPerScalar +
+       ComponentTypeTraits<DstTy>::ElementsPerScalar - 1) /
       ComponentTypeTraits<DstTy>::ElementsPerScalar;
 };
 


### PR DESCRIPTION
Updates `DstN` calculation to make sure the calculated value is rounded. 
Added description of the `DimMN` and `DstN` helper structs from the `__detail` namespace.