### PR TITLE
[0035] Remove CompileExplorer link

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1750,9 +1750,6 @@ in the [`DXIL::ComponentType` enumeration](#dxil-enumerations).
 
 ## Appendix 1: HLSL Header
 
-[Compiler Explorer](https://godbolt.org/z/5qzYaosf1)
-> Note: this mostly works with Clang, but has some issues to work out still.
-
 ```cpp
 namespace hlsl {
 


### PR DESCRIPTION
Remove link to compiler explorer (godbolt) with the HLSL header because it is hard to keep in sync. It is often forgotten to be updated when the spec changes, and it is a source of merge conflicts when multiple people edit the spec at the same time.