### PR TITLE
[0035] MultiplyAdd should convert Bias vector to output type

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1144,6 +1144,10 @@ may also be a `VectorRef` which refers to a vector in memory. Using the
 `VectorRef` overload makes it easier for the backend compiler to optimize the
 bias vector loads with the ALU operations.
 
+If the `Bias` vector's interpretation type differs from the output vector
+type, the `Bias` vector is converted to the output vector type before the
+multiply-add operation.
+
 ### DXIL Types
 
 This feature adds the following new DXIL enumerations, which used as immediate


### PR DESCRIPTION
For `MultiplyAdd(matrix, vector, vector)` the `Bias` vectors should be converted to output vector type before the multiply-add operation if necessary.