### PR TITLE
Update DebugBreak proposal langauge

### DIFF
--- a/proposals/0039-debugbreak.md
+++ b/proposals/0039-debugbreak.md
@@ -9,20 +9,20 @@ params:
     status: Under Review
 ---
 
- 
+
 * Issue(s): https://github.com/microsoft/hlsl-specs/issues/33
 
 ## Introduction
 
 This proposal specifies two new HLSL debugging intrinsics:
 
-1. **`DebugBreak()`**: Triggers a breakpoint when a debugger is attached,
+1. **`DebugBreak()`**: Triggers a breakpoint when debugging is enabled
    allowing developers to pause execution and inspect shader state.
-2. **`dx::IsDebuggerPresent()`**: Returns whether a graphics debugger is currently
-   attached to the process, enabling conditional debug-only code paths.
+2. **`dx::IsDebuggingEnabled()`**: Returns whether debugging is enabled for the
+   currently executing thread, enabling conditional debug-only code paths.
 
 `DebugBreak()` will lower to new DXIL operations for DirectX and to appropriate
-SPIR-V instructions for Vulkan targets. `dx::IsDebuggerPresent()` is a DirectX
+SPIR-V instructions for Vulkan targets. `dx::IsDebuggingEnabled()` is a DirectX
 extension and has no Vulkan/SPIR-V equivalent.
 
 ## Motivation
@@ -36,8 +36,8 @@ Conditional breakpoints can be a powerful tool for shader authors to narrow down
 and identify these complex rare-occurring problems.
 
 Additionally, shader authors need a way to conditionally enable expensive debug
-checks only when a debugger is attached, avoiding runtime overhead in production
-scenarios.
+checks only when debugging is enabled in the runtime, avoiding runtime overhead
+in production scenarios.
 
 This proposal introduces two intrinsics that together provide a debugging
 toolkit for shader development.
@@ -49,8 +49,8 @@ This proposal introduces two new HLSL intrinsics for debugging shader code.
 ### Intrinsics
 
 ```hlsl
-void DebugBreak();        // Trigger a breakpoint if debugger attached
-bool dx::IsDebuggerPresent(); // Query if a debugger is attached (DirectX only)
+void DebugBreak();        // Trigger a breakpoint if debugging is enabled.
+bool dx::IsDebuggingEnabled(); // Query if debugging is enabled (DirectX only).
 ```
 
 ### Example Usage
@@ -59,11 +59,11 @@ bool dx::IsDebuggerPresent(); // Query if a debugger is attached (DirectX only)
 [numthreads(8,1,1)]
 void main(uint GI : SV_GroupIndex) {
     // Conditional expensive debug checks
-  if (dx::IsDebuggerPresent()) {
+  if (dx::IsDebuggingEnabled()) {
         // Expensive validation only when debugging
         ValidateComplexInvariants();
     }
-    
+
     // Manual breakpoint for debugging specific conditions
     if (someRareCondition) {
         DebugBreak();
@@ -85,22 +85,22 @@ Two new intrinsic functions are added:
 void DebugBreak();
 ```
 
-Triggers a breakpoint if a graphics debugger is attached. If no debugger is
-attached or the runtime does not support this operation, it is treated as a
+Triggers a breakpoint if debugging is enabled in the runtime. If debugging is
+not enabled or the runtime does not support this operation, it is treated as a
 no-op. Execution continues after the breakpoint.
 
-#### `dx::IsDebuggerPresent()`
+#### `dx::IsDebuggingEnabled()`
 
 ```hlsl
-bool dx::IsDebuggerPresent();
+bool dx::IsDebuggingEnabled();
 ```
 
-Returns `true` if a graphics debugger is currently attached to the process,
-`false` otherwise. This allows shader authors to conditionally execute expensive
-debug validation code only when a debugger is present:
+Returns `true` if debugging is enabled on the current thread, `false` otherwise.
+This allows shader authors to conditionally execute expensive debug validation
+code only when debugging is enabled:
 
 ```hlsl
-if (dx::IsDebuggerPresent()) {
+if (dx::IsDebuggingEnabled()) {
     // Expensive bounds checking, validation, etc.
     for (uint i = 0; i < arraySize; ++i) {
         if (data[i] < 0.0f || data[i] > 1.0f) {
@@ -126,19 +126,19 @@ declare void @dx.op.debugBreak(
 ```
 
 Triggers a debugger breakpoint. Must be treated as `convergent` to prevent code
-motion. Should not be marked `readonly` or `readnone`. If no debugger is
-attached, this is a no-op.
+motion. Should not be marked `readonly` or `readnone`. If debugging is not
+enabled, this is a no-op.
 
-#### `dx.op.isDebuggerPresent`
+#### `dx.op.IsDebuggingEnabled`
 
 ```llvm
-declare i1 @dx.op.isDebuggerPresent(
+declare i1 @dx.op.IsDebuggingEnabled(
   immarg i32             ; opcode
 ) readonly
 ```
 
-Returns `true` (1) if a debugger is attached, `false` (0) otherwise. Marked
-`readonly` as it only queries state. 
+Returns `true` (1) if debugging is enabled, `false` (0) otherwise. Marked
+`readonly` as it only queries state.
 
 ### Convergence Requirements
 
@@ -162,10 +162,10 @@ per-pipeline basis.
 
 Behavioral changes may include:
 
-- Breaking regardless of a debugger being attached
+- Breaking regardless of a debugging enabled
 - Disabling debug break instructions entirely
 
-It is expected that the driver compiler will alter behavior during lowering 
+It is expected that the driver compiler will alter behavior during lowering
 based on information provided by the runtime at pipeline creation.
 
 ### SPIR-V Lowering
@@ -182,7 +182,7 @@ Uses the existing `NonSemantic.DebugBreak` instruction:
 While this instruction is not widely supported by Vulkan debuggers, it is
 supported by NVIDIA's NSight and can be safely ignored by Vulkan runtimes.
 
-No SPIR-V lowering is defined for `dx::IsDebuggerPresent()`.
+No SPIR-V lowering is defined for `dx::IsDebuggingEnabled()`.
 
 ## Testing
 
@@ -199,9 +199,9 @@ No SPIR-V lowering is defined for `dx::IsDebuggerPresent()`.
 
 ### Execution Testing
 
-- Test `DebugBreak()` triggers breakpoint when debugger attached
-- Test `DebugBreak()` is no-op when no debugger present
-- Test `dx::IsDebuggerPresent()` returns correct value based on debugger state
+- Test `DebugBreak()` triggers breakpoint when debugging is enabled
+- Test `DebugBreak()` is no-op when debugging is not enabled
+- Test `dx::IsDebuggingEnabled()` returns correct value based on runtime state
 
 ## Open Questions
 

--- a/proposals/0039-debugbreak.md
+++ b/proposals/0039-debugbreak.md
@@ -58,16 +58,16 @@ bool dx::IsDebuggingEnabled(); // Query if debugging is enabled (DirectX only).
 ```hlsl
 [numthreads(8,1,1)]
 void main(uint GI : SV_GroupIndex) {
-    // Conditional expensive debug checks
+  // Conditional expensive debug checks
   if (dx::IsDebuggingEnabled()) {
-        // Expensive validation only when debugging
-        ValidateComplexInvariants();
-    }
+    // Expensive validation only when debugging
+    ValidateComplexInvariants();
+  }
 
-    // Manual breakpoint for debugging specific conditions
-    if (someRareCondition) {
-        DebugBreak();
-    }
+  // Manual breakpoint for debugging specific conditions
+  if (someRareCondition) {
+    DebugBreak();
+  }
 }
 ```
 
@@ -122,12 +122,10 @@ This change introduces two new DXIL operations:
 ```llvm
 declare void @dx.op.debugBreak(
   immarg i32             ; opcode
-) convergent
+)
 ```
 
-Triggers a debugger breakpoint. Must be treated as `convergent` to prevent code
-motion. Should not be marked `readonly` or `readnone`. If debugging is not
-enabled, this is a no-op.
+Triggers a debugger breakpoint. If debugging is not enabled, this is a no-op.
 
 #### `dx.op.IsDebuggingEnabled`
 
@@ -139,14 +137,6 @@ declare i1 @dx.op.IsDebuggingEnabled(
 
 Returns `true` (1) if debugging is enabled, `false` (0) otherwise. Marked
 `readonly` as it only queries state.
-
-### Convergence Requirements
-
-`debugBreak` operations must be treated as `convergent` to prevent
-code motion that could change their observable behavior:
-- `debugBreak`: Must break at the exact location specified by the programmer
-
-These operations should not be hoisted, sunk, or duplicated by optimizers.
 
 ### Shader Model Requirements
 
@@ -195,17 +185,9 @@ No SPIR-V lowering is defined for `dx::IsDebuggingEnabled()`.
 
 - Confirm validation accepts the new operations in SM 6.10+
 - Confirm validation rejects operations in earlier shader models
-- Verify convergence requirements are properly validated
 
 ### Execution Testing
 
 - Test `DebugBreak()` triggers breakpoint when debugging is enabled
 - Test `DebugBreak()` is no-op when debugging is not enabled
 - Test `dx::IsDebuggingEnabled()` returns correct value based on runtime state
-
-## Open Questions
-
-* Consider introducing the `convergent` attribute to DXIL.
-  * This should be "cheap" and would potentially address pre-existing bugs.
-  * This would preserve the requirement that these operations not be moved
-    during optimization in the final DXIL.

--- a/proposals/0039-debugbreak.md
+++ b/proposals/0039-debugbreak.md
@@ -101,12 +101,12 @@ code only when debugging is enabled:
 
 ```hlsl
 if (dx::IsDebuggingEnabled()) {
-    // Expensive bounds checking, validation, etc.
-    for (uint i = 0; i < arraySize; ++i) {
-        if (data[i] < 0.0f || data[i] > 1.0f) {
-            DebugBreak();
-        }
+  // Expensive bounds checking, validation, etc.
+  for (uint i = 0; i < arraySize; ++i) {
+    if (data[i] < 0.0f || data[i] > 1.0f) {
+      DebugBreak();
     }
+  }
 }
 ```
 
@@ -152,7 +152,7 @@ per-pipeline basis.
 
 Behavioral changes may include:
 
-- Breaking regardless of a debugging enabled
+- Breaking regardless of debugging being enabled
 - Disabling debug break instructions entirely
 
 It is expected that the driver compiler will alter behavior during lowering


### PR DESCRIPTION
This is mostly clarifications that the behavior isn't actually dependent on a debugger being attached, but rather on runtime state (which will be set by a debugger, but may also be set separately).

I've also renamed `dx::IsDebuggerAttached` to `dx::IsDebuggingEnabled` to more clearly reflect the change.