### PR TITLE
Update VK SDK Release Spec

### DIFF
--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -119,7 +119,8 @@ opts in.
 4. **Offload tests.** A separate job runs the LLVM offload-test-suite against the
    published artifact, with DXC as the only compiler (the in-tree clang compiler is
    disabled). The Vulkan tests (`check-hlsl-vk`) on lavapipe and the Direct3D 12
-   tests (`check-hlsl-warp-d3d12`) on WARP. Because it consumes the published artifact
+   tests (`check-hlsl-warp-d3d12`) on WARP (developers still use the dxc which ships
+   in the Vulkan SDK to compile dx shaders). Because it consumes the published artifact
    rather than the build tree, this job can also be run on its own against any earlier candidate.
 
 ### Release manifest
@@ -150,12 +151,16 @@ candidate was built against and the tests results:
 These steps are performed by whoever is currently responsible for monitoring the
 llvm-build, and may be repeated as needed:
 
-1. Update the SPIRV-Headers and SPIRV-Tools submodules to the commits specified by
+1. File an issue in DXC repository using the `vk_release_checklist.md` issue template,
+   assign this to yourself. This should be handed off at the end of rotation. 
+3. Update the SPIRV-Headers and SPIRV-Tools submodules to the commits specified by
    LunarG.
-2. Create the `release/vulkan/<version>` branch, which triggers the pipeline.
-3. Check whether the resulting candidate is validated (see
+4. Create the `release/vulkan/<version>` branch, which triggers the pipeline.
+5. Check whether the resulting candidate is validated (see
    [Release Candidate readiness](#release-candidate-readiness)).
-4. Email the validated DXC commit back to LunarG.
+6. Tag the validated commit, `vulkan-sdk-<version>-rc`, as a release candidate
+7. Report that tag to LunarG. This can be done through email
+   or by updating Khronos GitLab release issue with the validated commit.
 
 ### Release Candidate readiness
 

--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -42,7 +42,9 @@ For an SDK release, the pipeline also publishes the candidate as an artifact and
 the LLVM [offload-test-suite](https://github.com/llvm/offload-test-suite) against it,
 using lavapipe as the SPIRV driver and WARP as the DXIL driver. DXC from the Vulkan SDK
 is also used to compile shader targeting DirectX, so its DXIL output is worth testing too. 
-LunarG is handed the validated DXC commit, recorded in the release candidate manifest.
+Each validated candidate handed to LunarG is tagged as a release candidate (its
+results recorded in the manifest); the latest is promoted to a release once the Vulkan
+SDK ships.
 
 The automation is split into three workflows, each shown below starting from its triggers:
 
@@ -146,6 +148,20 @@ candidate was built against and the tests results:
 }
 ```
 
+### Release tagging
+
+A release is prepared on a branch and shipped to LunarG as a series of release
+candidate tags. The branch carries the Vulkan SDK's major and minor version; each tag
+adds the patch version and a release-candidate number. For SDK version `1.4.360`, for
+example, the release branch is `release/vulkan/1.4.360`, the candidates sent to LunarG
+are tagged `1.4.360.0rc1`, `1.4.360.0rc2`, and so on, and once the Vulkan SDK is
+published the latest candidate is promoted to a release tag with no `rc` suffix:
+`1.4.360.0`.
+
+A single SDK release might involves more than one handoff: LunarG may surface an
+issue, which is fixed on the branch and re-validated before the next candidate tag is
+cut. Only the final, shipped candidate becomes the release.
+
 ### Release Steps
 
 These steps are performed by whoever is currently responsible for monitoring the
@@ -153,14 +169,19 @@ llvm-build, and may be repeated as needed:
 
 1. File an issue in DXC repository using the `vk_release_checklist.md` issue template,
    assign this to yourself. This should be handed off at the end of rotation. 
-3. Update the SPIRV-Headers and SPIRV-Tools submodules to the commits specified by
+2. Update the SPIRV-Headers and SPIRV-Tools submodules to the commits specified by
    LunarG.
-4. Create the `release/vulkan/<version>` branch, which triggers the pipeline.
-5. Check whether the resulting candidate is validated (see
+3. Create the `release/vulkan/<version>` branch — named for the SDK major and minor
+   version, e.g. `release/vulkan/1.4.360` — which triggers the pipeline.
+4. Check whether the resulting candidate is validated (see
    [Release Candidate readiness](#release-candidate-readiness)).
-6. Tag the validated commit, `vulkan-sdk-<version>-rc`, as a release candidate
-7. Report that tag to LunarG. This can be done through email
-   or by updating Khronos GitLab release issue with the validated commit.
+5. Tag the validated commit with the next release-candidate tag (e.g. `1.4.360.0rc1`)
+   and report that tag to LunarG — by email, or by updating the Khronos GitLab release
+   issue with the validated commit.
+6. If LunarG reports a problem, fix it on the release branch and re-validate, then cut
+   the next release-candidate tag (`...rc2`, and so on) and report it.
+7. Once the Vulkan SDK is published, promote the latest release-candidate tag to a
+   release tag with no `rc` suffix, e.g. `1.4.360.0`.
 
 ### Release Candidate readiness
 

--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -34,15 +34,15 @@ releases and can be ingested into Godbolt.
 
 The SPIRV-Headers and SPIRV-Tools submodules are the single source of truth for the
 SPIRV revisions a candidate is built against. Once a week a workflow bumps them to the
-latest upstream commit and opens a pull request to merge that bump into `main`. The
+latest upstream commit and opens a pull request to merge that update into `main`. The
 pull request runs the release-candidate pipeline, building DXC against
-the bumped submodules and running the SPIRV tests.
+the updated submodules and running the SPIRV tests.
 
 For an SDK release, the pipeline also publishes the candidate as an artifact and runs
 the LLVM [offload-test-suite](https://github.com/llvm/offload-test-suite) against it,
 using lavapipe as the SPIRV driver and WARP as the DXIL driver. DXC from the Vulkan SDK
-is also used for DirectX, so its DXIL output is worth testing too. The SDK builders are
-handed the validated DXC commit, recorded in the manifest, not the artifact.
+is also used to compile shader targeting DirectX, so its DXIL output is worth testing too. 
+LunarG is handed the validated DXC commit, recorded in the release candidate manifest.
 
 The automation is split into three workflows, each shown below starting from its triggers:
 
@@ -107,17 +107,16 @@ opts in.
    tests enabled. The build also produces the tools the tests need, including
    `spirv-val`.
 
-2. **Test.** Every SPIRV test in the DXC repo runs here, across all of its harnesses:
-   the googletest unit tests, the lit CodeGenSPIRV tests, and the TAEF tests; the
-   binary's output is then checked with `spirv-val`. Each result is recorded
-   in the manifest, including failed tests. The logs also contain further information
-   where each file is located and what was exected. This stage is non-blocking —
-   a release candidate is published even if some tests fail.
+2. **Test.** Googletest unit tests, the lit CodeGenSPIRV tests, and the TAEF tests are
+   all run in this stage; the binary's output is then checked with `spirv-val`. Each
+   result is recorded in the manifest, including failed tests. The logs also contain
+   further information where each file is located and what was exected. This stage is
+   non-blocking — a release candidate is published even if some tests fail.
 
-4. **Publish.** The DXC binaries (`dxc`, `dxv`, and `dxcompiler.dll`), the manifest,
+3. **Publish.** The DXC binaries (`dxc`, `dxv`, and `dxcompiler.dll`), the manifest,
    and the test reports are uploaded as a single artifact named `dxc_rc_<version>`.
 
-5. **Offload tests.** A separate job runs the LLVM offload-test-suite against the
+4. **Offload tests.** A separate job runs the LLVM offload-test-suite against the
    published artifact, with DXC as the only compiler (the in-tree clang compiler is
    disabled). The Vulkan tests (`check-hlsl-vk`) on lavapipe and the Direct3D 12
    tests (`check-hlsl-warp-d3d12`) on WARP. Because it consumes the published artifact
@@ -126,12 +125,13 @@ opts in.
 ### Release manifest
 
 The manifest records the DXC commit, the SPIRV-Headers and SPIRV-Tools commits the
-candidate was built against, the tests results, and a single `validated` flag
-that is true only when every test passed:
+candidate was built against and the tests results:
 
 ```json
 {
   "dxc_commit": "<sha>",
+  "lavapipe_version": "<version>",
+  "warp_version": "<version>",
   "spirv_dependencies": {
     "SPIRV-Headers": "<sha>",
     "SPIRV-Tools": "<sha>"
@@ -141,8 +141,7 @@ that is true only when every test passed:
     { "name": "spirv-codegen", "passed": 1564, "failed": 0 },
     { "name": "spirv-taef", "passed": 1, "failed": 0 },
     { "name": "spirv-val", "passed": 6, "failed": 0 }
-  ],
-  "validated": true
+  ]
 }
 ```
 
@@ -156,7 +155,7 @@ llvm-build, and may be repeated as needed:
 2. Create the `release/vulkan/<version>` branch, which triggers the pipeline.
 3. Check whether the resulting candidate is validated (see
    [Release Candidate readiness](#release-candidate-readiness)).
-4. Report the validated DXC commit to LunarG.
+4. Email the validated DXC commit back to LunarG.
 
 ### Release Candidate readiness
 
@@ -169,4 +168,3 @@ ready for the Vulkan SDK.
   SPIRV the binary emits validates under `spirv-val`.
 * The shaders the candidate compiles execute on the offload-test-suite under both
   software renderers: the SPIRV on lavapipe (Vulkan) and the DXIL on WARP (Direct3D 12).
-* The manifest records the result, with `validated` set to `true`.

--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -2,11 +2,11 @@
 title: "INF-0007 - DXC Vulkan SDK Release Strategy"
 params:
   authors:
-    - Damyan Pepper
-    - João Saffran
+    - damyanp: Damyan Pepper
+    - joaosaffran: João Saffran
   sponsors:
-    - Damyan Pepper
-    - João Saffran
+    - damyanp: Damyan Pepper
+    - joaosaffran: João Saffran
   status: Under Consideration
 ---
 

--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -32,37 +32,102 @@ releases and can be ingested into Godbolt.
 
 ## Proposed solution
 
-The automation is a single pipeline that prepares a release candidate, validates
-it, and publishes it as a build artifact for further testing. The SDK builders 
-do not consume that artifact; they are given the candidate's DXC commit, 
-which the manifest records. The dependencies a candidate is built against are 
-captured in a checked-in `known_good.json` file, which is the single source of 
-truth for which SPIRV-Headers and SPIRV-Tools revisions are shipped.
+The SPIRV-Headers and SPIRV-Tools submodules are the single source of truth for the
+SPIRV revisions a candidate is built against. Once a week a workflow bumps them to the
+latest upstream commit and opens a pull request to merge that bump into `main`. The
+pull request runs the release-candidate pipeline, building DXC against
+the bumped submodules and running the SPIRV tests.
 
-### Pipeline
+For an SDK release, the pipeline also publishes the candidate as an artifact and runs
+the LLVM [offload-test-suite](https://github.com/llvm/offload-test-suite) against it,
+using lavapipe as the SPIRV driver and WARP as the DXIL driver. DXC from the Vulkan SDK
+is also used for DirectX, so its DXIL output is worth testing too. The SDK builders are
+handed the validated DXC commit, recorded in the manifest, not the artifact.
 
-The pipeline has two triggers: creating a `release/vulkan/<version>` branch, or a
-manual run from the GitHub UI. The pipeline performs the following actions:
+The automation is split into three workflows, each shown below starting from its triggers:
 
-1. **Update dependencies.** SPIRV-Headers and SPIRV-Tools are updated
-   to the commit recorded in `known_good.json`.
+**1. Weekly submodule update** — keeps the SPIRV dependencies updated.
 
-2. **Build.** DXC is configured and built with SPIRV code generation and the SPIRV
-   tests enabled. It also builds the tools the tests depend on, such as `spirv-val`.
+```mermaid
+flowchart TD
+    cron(["Trigger: weekly schedule"]) --> bump
+    md1(["Trigger: manual dispatch"]) --> bump
+    bump["Bump SPIRV-Headers / SPIRV-Tools<br/>submodules to latest upstream"] --> changed{"Anything changed?"}
+    changed -->|no| stop(["Done — already current"])
+    changed -->|yes| pr["Open a vk-update PR"]
+    pr -. "branch push starts" .-> rc(["Release-candidate pipeline"])
+```
 
-3. **Test.** All of the SPIRV tests available in the DXC repo are run in this
-   stage: the lit tests, the googletest unit tests, and the TAEF tests. The
-   generated code is also validated with `spirv-val`. This stage is non-blocking: a
-   release candidate is published as a pipeline artifact even if some tests fail.
+**2. Release-candidate pipeline** — builds and tests DXC; for a release candidate it
+also publishes the artifact and runs the offload tests.
 
-4. **Publish.** The DXC binary, a machine-readable manifest, and the per-tool test
-   reports are published as a single artifact, named `dxc_rc_<version>`.
+```mermaid
+flowchart TD
+    push(["Trigger: push to a<br/>vk-update or release/vulkan branch"]) --> build
+    md2(["Trigger: manual dispatch"]) --> build
+    build["Build DXC against the<br/>submodule pointers, plus spirv-val"] --> test
+    test["Run every SPIRV test:<br/>googletest, lit, TAEF, spirv-val"] --> gate{"Release candidate?<br/>release/vulkan branch<br/>or manual opt-in"}
+    gate -->|no| prchecks(["Validation only — checks surface<br/>on the vk-update PR, merge when green"])
+    gate -->|yes| publish["Publish dxc_rc artifact + manifest"]
+    publish -. "consumed by" .-> offload(["Offload tests"])
+```
+
+**3. Offload tests** — runs the offload-test-suite against the published candidate on
+software renderers, split by API.
+
+```mermaid
+flowchart TD
+    called(["Trigger: called by the pipeline"]) --> get
+    md3(["Trigger: manual dispatch —<br/>run_id + artifact name"]) --> get
+    get["Download the dxc_rc artifact"] --> conf["Build offload-test-suite against<br/>the candidate's DXC — DXC only"]
+    conf --> vk["Vulkan: check-hlsl-vk on lavapipe<br/>runs the candidate's SPIRV"]
+    conf --> d3d["Direct3D 12: check-hlsl-warp-d3d12 on WARP<br/>runs the candidate's DXIL"]
+```
+
+### Dependency update
+
+A scheduled job runs once a week (and can be triggered on demand). Such advances the
+SPIRV-Headers and SPIRV-Tools submodules to their latest upstream commit and, if
+anything changed, commits the new pointers onto a fresh `vk-update/<date>` branch and
+opens a pull request against the default branch. Pushing that branch starts the
+release-candidate pipeline, whose checks attach to the commit and show on the pull
+request, so the bump is reviewed and merged only once the candidate is green. 
+
+### Release Pipeline
+
+The release pipeline runs on every push to a `vk-update/<date>` branch (the weekly job
+creates these) or a `release/vulkan/<version>` branch (cut by hand for a release;
+see [Release Steps](#Release Steps)), and can be started manually from the GitHub UI. 
+The build and test stages run on every push; the publish and offload stages run only 
+for a release candidate — a `release/vulkan/<version>` branch, or a manual run that 
+opts in.
+
+1. **Build.** DXC is checked out with its submodules, so it builds against exactly
+   the SPIRV the pointers name, configured with SPIRV code generation and the SPIRV
+   tests enabled. The build also produces the tools the tests need, including
+   `spirv-val`.
+
+2. **Test.** Every SPIRV test in the DXC repo runs here, across all of its harnesses:
+   the googletest unit tests, the lit CodeGenSPIRV tests, and the TAEF tests; the
+   binary's output is then checked with `spirv-val`. Each result is recorded
+   in the manifest, including failed tests. The logs also contain further information
+   where each file is located and what was exected. This stage is non-blocking —
+   a release candidate is published even if some tests fail.
+
+4. **Publish.** The DXC binaries (`dxc`, `dxv`, and `dxcompiler.dll`), the manifest,
+   and the test reports are uploaded as a single artifact named `dxc_rc_<version>`.
+
+5. **Offload tests.** A separate job runs the LLVM offload-test-suite against the
+   published artifact, with DXC as the only compiler (the in-tree clang compiler is
+   disabled). The Vulkan tests (`check-hlsl-vk`) on lavapipe and the Direct3D 12
+   tests (`check-hlsl-warp-d3d12`) on WARP. Because it consumes the published artifact
+   rather than the build tree, this job can also be run on its own against any earlier candidate.
 
 ### Release manifest
 
 The manifest records the DXC commit, the SPIRV-Headers and SPIRV-Tools commits the
-candidate was built against, the per-tool results, and a single `validated` flag
-that is true only when every tool passed:
+candidate was built against, the tests results, and a single `validated` flag
+that is true only when every test passed:
 
 ```json
 {
@@ -86,8 +151,8 @@ that is true only when every tool passed:
 These steps are performed by whoever is currently responsible for monitoring the
 llvm-build, and may be repeated as needed:
 
-1. Update `known_good.json` to the SPIRV-Headers and SPIRV-Tools commits specified
-   by LunarG.
+1. Update the SPIRV-Headers and SPIRV-Tools submodules to the commits specified by
+   LunarG.
 2. Create the `release/vulkan/<version>` branch, which triggers the pipeline.
 3. Check whether the resulting candidate is validated (see
    [Release Candidate readiness](#release-candidate-readiness)).
@@ -98,8 +163,10 @@ llvm-build, and may be repeated as needed:
 The following must be true and validated for a release candidate to be considered
 ready for the Vulkan SDK.
 
-* It builds against the SPIRV-Headers and SPIRV-Tools commits recorded in
-  `known_good.json`.
-* Every SPIRV testing tool passes, and the SPIRV the binary emits validates under
-  `spirv-val`.
+* It builds against the SPIRV-Headers and SPIRV-Tools commits the submodules are
+  pinned to.
+* Every SPIRV test harness passes — the googletest, lit, and TAEF tests — and the
+  SPIRV the binary emits validates under `spirv-val`.
+* The shaders the candidate compiles execute on the offload-test-suite under both
+  software renderers: the SPIRV on lavapipe (Vulkan) and the DXIL on WARP (Direct3D 12).
 * The manifest records the result, with `validated` set to `true`.

--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -152,15 +152,14 @@ candidate was built against and the tests results:
 
 A release is prepared on a branch and shipped to LunarG as a series of release
 candidate tags. The branch carries the Vulkan SDK's major and minor version; each tag
-adds the patch version and a release-candidate number. For SDK version `1.4.360`, for
-example, the release branch is `release/vulkan/1.4.360`, the candidates sent to LunarG
-are tagged `1.4.360.0rc1`, `1.4.360.0rc2`, and so on, and once the Vulkan SDK is
-published the latest candidate is promoted to a release tag with no `rc` suffix:
-`1.4.360.0`.
-
-A single SDK release might involves more than one handoff: LunarG may surface an
-issue, which is fixed on the branch and re-validated before the next candidate tag is
-cut. Only the final, shipped candidate becomes the release.
+records the full Vulkan SDK version and a release-candidate number, and is prefixed
+`vulkan-sdk-` so it reads as a Vulkan SDK version rather than being confused with DXC's
+own release tags (`v<major>.<minor>.YYMM.<patch>`). This matches the `vulkan-sdk-`
+tags SPIRV-Tools already uses for the SDK. For SDK version `1.4.360`, for example, the
+release branch is `release/vulkan/1.4.360`, the candidates sent to LunarG are tagged
+`vulkan-sdk-1.4.360.0rc1`, `vulkan-sdk-1.4.360.0rc2`, and so on, and once the Vulkan
+SDK is published the latest candidate is promoted to a release tag with no `rc` suffix:
+`vulkan-sdk-1.4.360.0`.
 
 ### Release Steps
 
@@ -175,13 +174,13 @@ llvm-build, and may be repeated as needed:
    version, e.g. `release/vulkan/1.4.360` — which triggers the pipeline.
 4. Check whether the resulting candidate is validated (see
    [Release Candidate readiness](#release-candidate-readiness)).
-5. Tag the validated commit with the next release-candidate tag (e.g. `1.4.360.0rc1`)
-   and report that tag to LunarG — by email, or by updating the Khronos GitLab release
-   issue with the validated commit.
+5. Tag the validated commit with the next release-candidate tag (e.g.
+   `vulkan-sdk-1.4.360.0rc1`) and report that tag to LunarG — by email, or by updating
+   the Khronos GitLab release issue with the validated commit.
 6. If LunarG reports a problem, fix it on the release branch and re-validate, then cut
    the next release-candidate tag (`...rc2`, and so on) and report it.
 7. Once the Vulkan SDK is published, promote the latest release-candidate tag to a
-   release tag with no `rc` suffix, e.g. `1.4.360.0`.
+   release tag with no `rc` suffix, e.g. `vulkan-sdk-1.4.360.0`.
 
 ### Release Candidate readiness
 

--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -32,8 +32,8 @@ releases and can be ingested into Godbolt.
 
 ## Proposed solution
 
-The automation is a single pipeline that: prepares a release candidate; validates
-it; and publishes it as a build artifact for further testing. The SDK builders 
+The automation is a single pipeline that prepares a release candidate, validates
+it, and publishes it as a build artifact for further testing. The SDK builders 
 do not consume that artifact; they are given the candidate's DXC commit, 
 which the manifest records. The dependencies a candidate is built against are 
 captured in a checked-in `known_good.json` file, which is the single source of 
@@ -41,31 +41,24 @@ truth for which SPIRV-Headers and SPIRV-Tools revisions are shipped.
 
 ### Pipeline
 
-The pipeline has two triggers: Creating a `release/vulkan/<version>` branch; 
-or manually in the github UI. When creating a new branch, SPIRV-Headers and 
-SPIRV-Tools, will automatically update to the most recent commit. When 
-triggering manually this step is optional. The pipelines performs the following
-actions:
+The pipeline has two triggers: creating a `release/vulkan/<version>` branch, or a
+manual run from the GitHub UI. The pipeline performs the following actions:
 
-1. **Update dependencies (optional).** SPIRV-Headers and SPIRV-Tools are updated
-   to the most common commit and such reference is updated in `known_good.json`.
-   This step is executed automatically when creating a release branch, or it can
-   be opted in when triggered manually.
+1. **Update dependencies.** SPIRV-Headers and SPIRV-Tools are updated
+   to the commit recorded in `known_good.json`.
 
 2. **Build.** DXC is configured and built with SPIRV code generation and the SPIRV
-   tests enabled, it also builds required test dependent tools, such as: `spirv-val`.
+   tests enabled. It also builds the tools the tests depend on, such as `spirv-val`.
 
-3. **Test.** All tests available for SPIRV in DXC repo are run in this stage. 
-   This includes: lit tests, google tests and TAEF tests. The generated code is 
-   also validated by `spirv-val`. This stage is non blocking, meaning a release
-   candidate will be published in the pipeline artifact section even if test fails.
-   This is done to not block further testing that might be unaffected by such tests failures.
-
+3. **Test.** All of the SPIRV tests available in the DXC repo are run in this
+   stage: the lit tests, the googletest unit tests, and the TAEF tests. The
+   generated code is also validated with `spirv-val`. This stage is non-blocking: a
+   release candidate is published as a pipeline artifact even if some tests fail.
 
 4. **Publish.** The DXC binary, a machine-readable manifest, and the per-tool test
    reports are published as a single artifact, named `dxc_rc_<version>`.
 
-### Release Manifest
+### Release manifest
 
 The manifest records the DXC commit, the SPIRV-Headers and SPIRV-Tools commits the
 candidate was built against, the per-tool results, and a single `validated` flag
@@ -88,7 +81,19 @@ that is true only when every tool passed:
 }
 ```
 
-### Release readiness
+### Release Steps
+
+These steps are performed by whoever is currently responsible for monitoring the
+llvm-build, and may be repeated as needed:
+
+1. Update `known_good.json` to the SPIRV-Headers and SPIRV-Tools commits specified
+   by LunarG.
+2. Create the `release/vulkan/<version>` branch, which triggers the pipeline.
+3. Check whether the resulting candidate is validated (see
+   [Release Candidate readiness](#release-candidate-readiness)).
+4. Report the validated DXC commit to LunarG.
+
+### Release Candidate readiness
 
 The following must be true and validated for a release candidate to be considered
 ready for the Vulkan SDK.

--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -2,11 +2,11 @@
 title: "INF-0007 - DXC Vulkan SDK Release Strategy"
 params:
   authors:
-    - damyanp: Damyan Pepper
-    - joaosaffran: João Saffran
+    - Damyan Pepper
+    - João Saffran
   sponsors:
-    - damyanp: Damyan Pepper
-    - joaosaffran: João Saffran
+    - Damyan Pepper
+    - João Saffran
   status: Under Consideration
 ---
 
@@ -32,47 +32,40 @@ releases and can be ingested into Godbolt.
 
 ## Proposed solution
 
-We automate this as a single pipeline that prepares a release candidate, validates
-it, and publishes it as a build artifact for the SDK builders to consume. We
-capture the dependencies a candidate is built against in a checked-in
-`known_good.json` file, which is the single source of truth for which SPIRV-Headers
-and SPIRV-Tools revisions we ship. The pipeline keeps that file current
-automatically when a new release branch is cut, so candidates track the latest
-SPIRV changes without a manual submodule bump.
+The automation is a single pipeline that: prepares a release candidate; validates
+it; and publishes it as a build artifact for further testing. The SDK builders 
+do not consume that artifact; they are given the candidate's DXC commit, 
+which the manifest records. The dependencies a candidate is built against are 
+captured in a checked-in `known_good.json` file, which is the single source of 
+truth for which SPIRV-Headers and SPIRV-Tools revisions are shipped.
 
 ### Pipeline
 
-The pipeline has two triggers. Creating a `release/vulkan/<version>` branch starts
-it automatically; it can also be started manually against an existing branch. The
-trigger only affects how the SPIRV dependencies are resolved (step 1); the
-remaining steps are identical. It performs the following steps:
+The pipeline has two triggers: Creating a `release/vulkan/<version>` branch; 
+or manually in the github UI. When creating a new branch, SPIRV-Headers and 
+SPIRV-Tools, will automatically update to the most recent commit. When 
+triggering manually this step is optional. The pipelines performs the following
+actions:
 
-1. **Update dependencies.** We take SPIRV-Headers and SPIRV-Tools to the commits
-   recorded in `known_good.json`. When a `release/vulkan/<version>` branch is
-   created we first advance `known_good.json` to the latest upstream commit of
-   each dependency, so a freshly cut candidate always picks up the most recent
-   SPIRV changes. On a manual run this update is optional and off by default: we
-   use the commits already recorded in `known_good.json` unchanged, so a specific
-   candidate can be reproduced or re-tested, unless the run asks for a refresh. In
-   every case we write the resolved commits back to `known_good.json` and record
-   them in the manifest, which keeps the build deterministic and the choice of
-   revisions reviewable.
+1. **Update dependencies (optional).** SPIRV-Headers and SPIRV-Tools are updated
+   to the most common commit and such reference is updated in `known_good.json`.
+   This step is executed automatically when creating a release branch, or it can
+   be opted in when triggered manually.
 
-2. **Build.** We configure and build DXC with SPIRV code generation and the SPIRV
-   tests enabled, together with the SPIRV-Tools validator (`spirv-val`) that we use
-   to independently check the generated SPIRV. A build failure is fatal — there is
-   no release candidate without a binary.
+2. **Build.** DXC is configured and built with SPIRV code generation and the SPIRV
+   tests enabled, it also builds required test dependent tools, such as: `spirv-val`.
 
-3. **Test.** After a successful build, we run the SPIRV tests using all of the
-   testing tools the DXC repo provides — the lit tests, the TAEF tests, and the
-   googletest unit tests — and we additionally validate the SPIRV the binary emits
-   with `spirv-val`. All of these run against that single build, on the worker that
-   produced it, and we run every SPIRV test regardless of which tool hosts it so
-   that "the SPIRV tests" means the complete set rather than one tool's subset.
+3. **Test.** All tests available for SPIRV in DXC repo are run in this stage. 
+   This includes: lit tests, google tests and TAEF tests. The generated code is 
+   also validated by `spirv-val`. This stage is non blocking, meaning a release
+   candidate will be published in the pipeline artifact section even if test fails.
+   This is done to not block further testing that might be unaffected by such tests failures.
 
-4. **Publish.** We publish the DXC binary, a machine-readable manifest, and the
-   per-tool test reports as a single artifact, named `dxc_rc_<version>` after the
-   SDK version the release branch targets, for downstream consumption.
+
+4. **Publish.** The DXC binary, a machine-readable manifest, and the per-tool test
+   reports are published as a single artifact, named `dxc_rc_<version>`.
+
+### Release Manifest
 
 The manifest records the DXC commit, the SPIRV-Headers and SPIRV-Tools commits the
 candidate was built against, the per-tool results, and a single `validated` flag
@@ -95,9 +88,6 @@ that is true only when every tool passed:
 }
 ```
 
-The manifest is the handoff to the SDK builders: it is the automated replacement
-for manually communicating the commit identifiers.
-
 ### Release readiness
 
 The following must be true and validated for a release candidate to be considered
@@ -108,62 +98,3 @@ ready for the Vulkan SDK.
 * Every SPIRV testing tool passes, and the SPIRV the binary emits validates under
   `spirv-val`.
 * The manifest records the result, with `validated` set to `true`.
-
-The `validated` flag is the single, machine-readable gate. An SDK builder consumes
-a candidate only when it is `true`.
-
-### Key decisions
-
-* **Determinism through `known_good.json`.** Whatever revisions a run resolves —
-  the recorded commits or a fresh upstream bump — we write back to
-  `known_good.json`, so every candidate is reproducible from that file alone and
-  the choice of SPIRV revisions stays an explicit, reviewable record rather than a
-  moving branch tip.
-
-* **Dependency refresh is tied to the trigger.** Cutting a release branch
-  refreshes the SPIRV dependencies to the latest upstream commits automatically,
-  so new candidates track upstream without a manual bump. Manual runs instead
-  default to the recorded commits — so any candidate can be reproduced or
-  re-tested exactly — and can opt into a refresh when wanted. The recorded
-  `known_good.json` keeps both paths auditable.
-
-* **Test failures do not block publication.** Only build failures stop the
-  pipeline. We record test failures in the manifest and surface them through the
-  `validated` flag, but still publish the candidate. The decision to release a
-  candidate rests with the team making the release, not with the CI/CD tooling:
-  the pipeline reports the results, and the team gates on `validated` when deciding
-  whether a candidate is acceptable.
-
-* **A single build feeds every test tool.** DXC's SPIRV coverage is spread across
-  multiple testing tools. The build is the expensive step, and CMake's outputs are
-  tied to the worker that produced them, so we run all of the tools against that
-  one build on the same worker rather than distributing them across runners. Being
-  otherwise independent, they can be run concurrently on that worker.
-
-* **The handoff goes through the manifest.** The handoff to the SDK builders and
-  the readiness decision are both driven by the manifest, so the integration does
-  not depend on out-of-band communication of commit identifiers.
-
-## Detailed design
-
-### Changed behavior
-
-This proposal adds release automation around DXC and does not change the
-compiler's behavior or any of its interfaces. The only repository additions are
-the `known_good.json` dependency pin, the pipeline definition, and the helper
-scripts that drive build, test, and validation.
-
-### How this is tested
-
-The pipeline is self-validating: its test step is the regression gate for SPIRV
-generation against the pinned dependencies, covering every SPIRV testing tool plus
-an independent `spirv-val` check of the SPIRV the binary emits. The
-`validated` flag in the manifest is the single signal both humans and downstream
-automation read.
-
-### Resources
-
-The pipeline requires CI capacity for a DXC build plus the SPIRV test run on the
-platform DXC ships from. No additional hardware or human resources are required,
-and no per-release manual coordination is expected beyond reviewing a
-`known_good.json` update.

--- a/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
+++ b/proposals/infra/INF-0007-DXC-Vulkan-SDK-Release-Strategy.md
@@ -2,9 +2,11 @@
 title: "INF-0007 - DXC Vulkan SDK Release Strategy"
 params:
   authors:
-    - damyanp: Damyan Pepper
+    - Damyan Pepper
+    - João Saffran
   sponsors:
-    - damyanp: Damyan Pepper
+    - Damyan Pepper
+    - João Saffran
   status: Under Consideration
 ---
 
@@ -30,40 +32,138 @@ releases and can be ingested into Godbolt.
 
 ## Proposed solution
 
-TODO
+We automate this as a single pipeline that prepares a release candidate, validates
+it, and publishes it as a build artifact for the SDK builders to consume. We
+capture the dependencies a candidate is built against in a checked-in
+`known_good.json` file, which is the single source of truth for which SPIRV-Headers
+and SPIRV-Tools revisions we ship. The pipeline keeps that file current
+automatically when a new release branch is cut, so candidates track the latest
+SPIRV changes without a manual submodule bump.
 
-<!-- Describe your solution to the problem. Provide examples and describe how
-they work. Show how your solution is better than current workarounds: is it
-cleaner, safer, or more efficient? -->
+### Pipeline
 
+The pipeline has two triggers. Creating a `release/vulkan/<version>` branch starts
+it automatically; it can also be started manually against an existing branch. The
+trigger only affects how the SPIRV dependencies are resolved (step 1); the
+remaining steps are identical. It performs the following steps:
 
-<!--
+1. **Update dependencies.** We take SPIRV-Headers and SPIRV-Tools to the commits
+   recorded in `known_good.json`. When a `release/vulkan/<version>` branch is
+   created we first advance `known_good.json` to the latest upstream commit of
+   each dependency, so a freshly cut candidate always picks up the most recent
+   SPIRV changes. On a manual run this update is optional and off by default: we
+   use the commits already recorded in `known_good.json` unchanged, so a specific
+   candidate can be reproduced or re-tested, unless the run asks for a refresh. In
+   every case we write the resolved commits back to `known_good.json` and record
+   them in the manifest, which keeps the build deterministic and the choice of
+   revisions reviewable.
+
+2. **Build.** We configure and build DXC with SPIRV code generation and the SPIRV
+   tests enabled, together with the SPIRV-Tools validator (`spirv-val`) that we use
+   to independently check the generated SPIRV. A build failure is fatal — there is
+   no release candidate without a binary.
+
+3. **Test.** After a successful build, we run the SPIRV tests using all of the
+   testing tools the DXC repo provides — the lit tests, the TAEF tests, and the
+   googletest unit tests — and we additionally validate the SPIRV the binary emits
+   with `spirv-val`. All of these run against that single build, on the worker that
+   produced it, and we run every SPIRV test regardless of which tool hosts it so
+   that "the SPIRV tests" means the complete set rather than one tool's subset.
+
+4. **Publish.** We publish the DXC binary, a machine-readable manifest, and the
+   per-tool test reports as a single artifact, named `dxc_rc_<version>` after the
+   SDK version the release branch targets, for downstream consumption.
+
+The manifest records the DXC commit, the SPIRV-Headers and SPIRV-Tools commits the
+candidate was built against, the per-tool results, and a single `validated` flag
+that is true only when every tool passed:
+
+```json
+{
+  "dxc_commit": "<sha>",
+  "spirv_dependencies": {
+    "SPIRV-Headers": "<sha>",
+    "SPIRV-Tools": "<sha>"
+  },
+  "test_suites": [
+    { "name": "spirv-unit", "passed": 105, "failed": 0 },
+    { "name": "spirv-codegen", "passed": 1564, "failed": 0 },
+    { "name": "spirv-taef", "passed": 1, "failed": 0 },
+    { "name": "spirv-val", "passed": 6, "failed": 0 }
+  ],
+  "validated": true
+}
+```
+
+The manifest is the handoff to the SDK builders: it is the automated replacement
+for manually communicating the commit identifiers.
+
+### Release readiness
+
+The following must be true and validated for a release candidate to be considered
+ready for the Vulkan SDK.
+
+* It builds against the SPIRV-Headers and SPIRV-Tools commits recorded in
+  `known_good.json`.
+* Every SPIRV testing tool passes, and the SPIRV the binary emits validates under
+  `spirv-val`.
+* The manifest records the result, with `validated` set to `true`.
+
+The `validated` flag is the single, machine-readable gate. An SDK builder consumes
+a candidate only when it is `true`.
+
+### Key decisions
+
+* **Determinism through `known_good.json`.** Whatever revisions a run resolves —
+  the recorded commits or a fresh upstream bump — we write back to
+  `known_good.json`, so every candidate is reproducible from that file alone and
+  the choice of SPIRV revisions stays an explicit, reviewable record rather than a
+  moving branch tip.
+
+* **Dependency refresh is tied to the trigger.** Cutting a release branch
+  refreshes the SPIRV dependencies to the latest upstream commits automatically,
+  so new candidates track upstream without a manual bump. Manual runs instead
+  default to the recorded commits — so any candidate can be reproduced or
+  re-tested exactly — and can opt into a refresh when wanted. The recorded
+  `known_good.json` keeps both paths auditable.
+
+* **Test failures do not block publication.** Only build failures stop the
+  pipeline. We record test failures in the manifest and surface them through the
+  `validated` flag, but still publish the candidate. The decision to release a
+  candidate rests with the team making the release, not with the CI/CD tooling:
+  the pipeline reports the results, and the team gates on `validated` when deciding
+  whether a candidate is acceptable.
+
+* **A single build feeds every test tool.** DXC's SPIRV coverage is spread across
+  multiple testing tools. The build is the expensive step, and CMake's outputs are
+  tied to the worker that produced them, so we run all of the tools against that
+  one build on the same worker rather than distributing them across runners. Being
+  otherwise independent, they can be run concurrently on that worker.
+
+* **The handoff goes through the manifest.** The handoff to the SDK builders and
+  the readiness decision are both driven by the manifest, so the integration does
+  not depend on out-of-band communication of commit identifiers.
 
 ## Detailed design
 
-_The detailed design is not required until the feature is under review._
+### Changed behavior
 
-This section should grow into a full specification that will provide enough
-information for someone who isn't the proposal author to implement the feature.
-It should also serve as the basis for documentation for the feature. Each
-feature will need different levels of detail here, but some common things to
-think through are:
+This proposal adds release automation around DXC and does not change the
+compiler's behavior or any of its interfaces. The only repository additions are
+the `known_good.json` dependency pin, the pipeline definition, and the helper
+scripts that drive build, test, and validation.
 
-* Is there any potential for changed behavior?
-* Will this expose new interfaces that will have support burden?
-* How will this proposal be tested?
-* Does this require additional hardware/software/human resources?
-* What documentation should be updated or authored?
+### How this is tested
 
-## Alternatives considered (Optional)
+The pipeline is self-validating: its test step is the regression gate for SPIRV
+generation against the pinned dependencies, covering every SPIRV testing tool plus
+an independent `spirv-val` check of the SPIRV the binary emits. The
+`validated` flag in the manifest is the single signal both humans and downstream
+automation read.
 
-If alternative solutions were considered, please provide a brief overview. This
-section can also be populated based on conversations that occur during
-reviewing.
+### Resources
 
-## Acknowledgments (Optional)
-
-Take a moment to acknowledge the contributions of people other than the author
-and sponsor.
-
-
+The pipeline requires CI capacity for a DXC build plus the SPIRV test run on the
+platform DXC ships from. No additional hardware or human resources are required,
+and no per-release manual coordination is expected beyond reviewing a
+`known_good.json` update.


### PR DESCRIPTION
This patch proposes a set of steps required to be performed to release DXC into the VK SDK.