### PR TITLE
Mark proposal 0039 (Debugging Intrinsics) as Accepted

### DIFF
--- a/proposals/0039-debugbreak.md
+++ b/proposals/0039-debugbreak.md
@@ -6,7 +6,7 @@ params:
     - joecitizen: Jack Elliott
     sponsors:
     - llvm-beanz: Chris Bieneman
-    status: Under Review
+    status: Accepted
 ---
 
  


### PR DESCRIPTION
This PR moves proposal 0039 (Debugging Intrinsics) from **Under Review** to **Accepted**.

Per the [proposal process](https://github.com/microsoft/hlsl-specs/blob/main/docs/Process.md#accepting-a-proposal): after the review period concludes and all outstanding issues are addressed, a sponsor creates a PR to mark the proposal as Accepted, at which point implementation PRs may begin.

The only change is the frontmatter `status` field; no other edits.

Issue: #33

Closes #704 
