### PR TITLE
[0035] Remove redundant bias interpretation type

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1801,8 +1801,7 @@ declare <[NUMo] x [TYo]> @dx.op.linAlgMatVecMulAdd.v[NUMo][TYo].[MatTy].v[NUMi][
   immarg i1,                          ; is output signed
   <[NUMi] x [TYi]>,                   ; input vector
   immarg i32,                         ; input interpretation type (DXIL::ComponentType)
-  <[NUMo] x [TYb]>,                   ; bias vector
-  immarg i32                          ; bias interpretation type (DXIL::ComponentType)
+  <[NUMo] x [TYb]>                   ; bias vector
   )
 ```
 
@@ -1812,6 +1811,7 @@ of `Thread` scope with a bias vector added to the result.
 Validation will enforce that:
 * The input vector length matches the `K` matrix dimension
 * The bias vector length matches the `M` matrix dimension
+* The bias vector's element type and length must match the output vector type.
 * The matrix A is an `A` matrix of `Thread` scope
 * The input and bias interpretation type must be one of the valid linalg
   component types specified in the list in the

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1810,8 +1810,8 @@ of `Thread` scope with a bias vector added to the result.
 
 Validation will enforce that:
 * The input vector length matches the `K` matrix dimension
-* The bias vector length matches the `M` matrix dimension
-* The bias vector's element type and length must match the output vector type.
+* The bias vector and output vector length matches the `M` matrix dimension
+* The bias vector's element type matches the output vector type.
 * The matrix A is an `A` matrix of `Thread` scope
 * The input and bias interpretation type must be one of the valid linalg
   component types specified in the list in the


### PR DESCRIPTION
Since we always load and convert the bias to the output type this argument is redundant.

Fixes #870