### PR TITLE
[0035] Alignment should always be an immarg

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1573,7 +1573,7 @@ Validation rules will enforce that:
 * `Stride` is `0` if the `Layout` is not `RowMajor` or `ColMajor`
 * If the matrix scope is `Thread` the resource handle must be an SRV
   ByteAddressBuffer
-* alignment must be a multiple of 128
+* Alignment must be a multiple of 128
 
 ```llvm
 declare %dx.types.LinAlgMatrix<mangling> @dx.op.linAlgMatrixLoadFromMemory.[MatTy].[Ty](

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1557,7 +1557,7 @@ declare %dx.types.LinAlgMatrix<mangling> @dx.op.linAlgMatrixLoadFromDescriptor.[
   i32,                   ; Offset
   i32,                   ; Stride
   i32,                   ; matrix layout
-  i32                    ; alignment
+  immarg i32             ; alignment
   )
 ```
 
@@ -1571,7 +1571,9 @@ Validation rules will enforce that:
 * `Layout` is `RowMajor` or `ColMajor` for matrix with `MatrixScope` of `Wave`
   or `ThreadGroup`
 * `Stride` is `0` if the `Layout` is not `RowMajor` or `ColMajor`
-* If the matrix scope is `Thread` the resource handle must be an SRV ByteAddressBuffer
+* If the matrix scope is `Thread` the resource handle must be an SRV
+  ByteAddressBuffer
+* alignment must be a multiple of 128
 
 ```llvm
 declare %dx.types.LinAlgMatrix<mangling> @dx.op.linAlgMatrixLoadFromMemory.[MatTy].[Ty](
@@ -1666,7 +1668,7 @@ declare void @dx.op.linAlgMatrixStoreToDescriptor.[MatTy](
   i32,                                ; Offset
   i32,                                ; Stride
   i32,                                ; matrix layout
-  i32                                 ; alignment
+  immarg i32                          ; alignment
   )
 ```
 
@@ -1678,6 +1680,7 @@ Validation rules will enforce that:
 * `Layout` is `RowMajor` or `ColMajor`
 * The matrix scope must be `Wave` or `ThreadGroup`
 * The resource handle must be an UAV RWByteAddressBuffer
+* Alignment must be a multiple of 128
 
 ```llvm
 declare void @dx.op.linAlgMatrixStoreToMemory.[MatTy].[Ty](
@@ -1850,7 +1853,7 @@ declare void @dx.op.linAlgMatrixAccumulateToDescriptor.[MatTy](
   i32,                                ; Offset
   i32,                                ; Stride
   i32,                                ; matrix layout
-  i32                                 ; alignment
+  immarg i32                          ; alignment
   )
 ```
 
@@ -1867,6 +1870,7 @@ Validation rules will enforce that:
   or `ThreadGroup`
 * `Stride` is `0` if the `Layout` is not `RowMajor` or `ColMajor`
 * The resource handle must be an UAV RWByteAddressBuffer
+* Alignment must be a multiple of 128
 
 ```llvm
 declare void @dx.op.linAlgMatrixAccumulateToMemory.[MatTy].[Ty](


### PR DESCRIPTION
This codifies that alignement is an immediate argument and must be such.