### PR TITLE
[0035] Add BFloat16 format

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1447,6 +1447,7 @@ enum class ComponentType : uint32_t {
   U8 = 20,
   F8_E4M3FN = 21,
   F8_E5M2 = 22,
+  BFloat16 = 23,
   // END
 
   LastEntry
@@ -2232,6 +2233,7 @@ struct ComponentType {
     __COMPONENT_TYPE(F16),
     __COMPONENT_TYPE(F32),
     __COMPONENT_TYPE(F64),
+    __COMPONENT_TYPE(BFloat16),
   };
 };
 

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1489,6 +1489,7 @@ of the valid linalg component types listed below:
 * `ComponentType::F8_E4M3FN`
 * `ComponentType::F8_E5M2`
 * `ComponentType::F16`
+* `ComponentType::Bfloat16`
 * `ComponentType::F32`
 * `ComponentType::F64`
 
@@ -2198,6 +2199,7 @@ enum class ComponentType : uint32_t {
   U8 = 20,
   F8_E4M3FN = 21,
   F8_E5M2 = 22,
+  BFloat16 = 23,
   // END
 
   LastEntry

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -647,6 +647,7 @@ enum class ComponentType : uint32_t {
   U8 = 20,
   F8_E4M3FN = 21,
   F8_E5M2 = 22,
+  BFloat16 = 23,
   // END
 
   LastEntry
@@ -682,6 +683,7 @@ struct ComponentType {
     __COMPONENT_TYPE(F16),
     __COMPONENT_TYPE(F32),
     __COMPONENT_TYPE(F64),
+    __COMPONENT_TYPE(BFloat16),
   };
 };
 


### PR DESCRIPTION
Add eunmeration for bfloat16 support. This is an optional feature that hardware vendors can choose to support.