### PR TITLE
[0035] Minor wording fix for MatVecMulAdd Op

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1838,11 +1838,10 @@ of `Thread` scope with a bias vector added to the result.
 Validation will enforce that:
 * The input vector length matches the `K` matrix dimension
 * The bias vector and output vector length matches the `M` matrix dimension
-* The bias vector's element type matches the output vector type.
+* The bias vector's element type matches the output vector's element type.
 * The matrix A is an `A` matrix of `Thread` scope
-* The input and bias interpretation type must be one of the valid linalg
-  component types specified in the list in the
-  [LinAlg Component Types](#linalg-component-types) section.
+* The input must be one of the valid linalg component types specified in the
+  list in the [LinAlg Component Types](#linalg-component-types) section.
 * The sign bit for output types should always be true if the output type is
   a vector of native floating point types.
 

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1840,8 +1840,9 @@ Validation will enforce that:
 * The bias vector and output vector length matches the `M` matrix dimension
 * The bias vector's element type matches the output vector's element type.
 * The matrix A is an `A` matrix of `Thread` scope
-* The input must be one of the valid linalg component types specified in the
-  list in the [LinAlg Component Types](#linalg-component-types) section.
+* The input interpretation type must be one of the valid linalg component types
+  specified in the list in the [LinAlg Component Types](#linalg-component-types)
+  section.
 * The sign bit for output types should always be true if the output type is
   a vector of native floating point types.
 


### PR DESCRIPTION
Removes line about the now removed bias interpretation and clarifies a statement that element types must be identical