### PR TITLE
[0035] Add bfloat16 type trait

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -799,6 +799,12 @@ template <typename T> struct TypeTraits {
       (ComponentEnum)dxil::ComponentType::Invalid;
 };
 
+template<> struct ComponentTypeTraits<ComponentType::BFloat16> {
+  using Type = uint;
+  static const bool IsNativeScalar = false;
+  static const uint ElementsPerScalar = 2;
+};
+
 #define __MATRIX_SCALAR_COMPONENT_MAPPING(enum_val, type)                      \
   template <> struct ComponentTypeTraits<enum_val> {                           \
     using Type = type;                                                         \
@@ -2283,6 +2289,12 @@ template <ComponentEnum CompTy> struct ComponentTypeTraits {
 template <typename T> struct TypeTraits {
   static const ComponentEnum CompType =
       (ComponentEnum)dxil::ComponentType::Invalid;
+};
+
+template<> struct ComponentTypeTraits<ComponentType::BFloat16> {
+  using Type = uint;
+  static const bool IsNativeScalar = false;
+  static const uint ElementsPerScalar = 2;
 };
 
 #define __MATRIX_SCALAR_COMPONENT_MAPPING(enum_val, type)                      \


### PR DESCRIPTION
The addition of the bfloat16 type missed updating the type traits.