### PR TITLE
[0046][0018] Update DXIL 1.10 for WG removal

### DIFF
--- a/proposals/0018-work-graphs.md
+++ b/proposals/0018-work-graphs.md
@@ -10,9 +10,12 @@ params:
   status: Completed
 ---
 
+* Version: SM 6.8
+* Removed: SM 6.10
 
- 
-* Planned Version: SM 6.8
+> Work Graphs was introduced in Shader Model 6.8, and has been removed effective
+> Shader Model 6.10. Driver support for Work Graphs is still available and
+> supported on many devices.
 
 ## Introduction
 

--- a/proposals/0046-dxil110.md
+++ b/proposals/0046-dxil110.md
@@ -66,6 +66,11 @@ together with a way for shader authors to declare the maximum amount of group
 shared memory their shader will ever use so that they can guarantee portability
 across a target device set.
 
+### Removing Support for Node Shaders
+
+[Proposal 0018] - Work Graphs
+
+DXIL 1.10 removes support for "node" shaders.
 
 
 [Proposal 0035]: 0035-linalg-matrix.md


### PR DESCRIPTION
With DXIL 1.10 we're removing support for Work Graphs. This does not remove support from the D3D API nor does it remove support from drivers, it merely disallows mixing newer SM 6.10+ features with Work Graphs freezing the feature level at SM 6.9.