### PR TITLE
[0035] Relax alignment requirements on wave and threadgroup

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1008,7 +1008,7 @@ the first element of the matrix (base address of the resource + the offset) must
 be 128-byte aligned for `Thread` scope matrices. For `Wave` and `ThreadGroup`
 scope matrices alignment must be at least 4, but will aim to default to a wider
 alignment for better performance. The `Stride` argument must be a multiple of 16
-bytes.
+bytes for `Thread` scope matrices and 4 bytes for `Wave` and `ThreadGroup`.
 
 For the `Load` operations on `groupshared` arrays:
   - an element is a type matching the element type of the `groupshared` array.

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -115,11 +115,11 @@ class Matrix {
       typename hlsl::enable_if<hlsl::is_arithmetic<T>::value, Matrix>::type
       Splat(T Val);
 
-  template <uint Align = 16>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   static Matrix Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
                      MatrixLayoutEnum Layout);
 
-  template <uint Align = 16>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   static Matrix Load(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                      MatrixLayoutEnum Layout);
 
@@ -153,7 +153,7 @@ class Matrix {
                            void>::type
   Set(uint Index, ElementType Value);
 
-  template <uint Align = 16>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   void Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
              MatrixLayoutEnum Layout);
 
@@ -168,7 +168,8 @@ class Matrix {
         MatrixLayoutEnum Layout);
 
   // Accumulate methods
-  template <uint Align = 16, MatrixUseEnum UseLocal = Use>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value,
+            MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
@@ -855,6 +856,15 @@ struct ScalarCountFromPackedComponents {
       (PackedComponentCount + ElementsPerScalar - 1) / ElementsPerScalar;
 };
 
+template <ComponentEnum ElementType, SIZE_TYPE M, SIZE_TYPE N>
+struct DefaultAlign {
+  static const SIZE_TYPE MinDim = M < N ? M : N;
+  static const uint ElementAlign =
+      ScalarCountFromPackedComponents<ElementType, MinDim>::Value;
+  static const uint MinElementAlign = ElementAlign < 4 ? 4 : ElementAlign;
+  static const uint Value = MinElementAlign < 16 ? MinElementAlign : 16;
+};
+
 } // namespace __detail
 ```
 
@@ -941,7 +951,7 @@ static Matrix Matrix::Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
                            MatrixLayoutEnum Layout);
 
 // Not available on Thread scope matrices.
-template <uint Align = 16>
+template <uint Align>
 static Matrix Matrix::Load(RWByteAddressBuffer Res, uint StartOffset,
                            uint Stride, MatrixLayoutEnum Layout);
 
@@ -995,8 +1005,9 @@ For the `Load` operations on `[RW]ByteAddressBuffers`:
 For overloads operating on device memory (`[RW]ByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
 be 128-byte aligned for `Thread` scope matrices. For `Wave` and `ThreadGroup`
-scope matrices alignment must be at least 16. The `Stride` argument must be a
-multiple of 16 bytes.
+scope matrices alignment must be at least 4, but will aim to default to a wider
+alignment for better performance. The `Stride` argument must be a multiple of 16
+bytes.
 
 For the `Load` operations on `groupshared` arrays:
   - an element is a type matching the element type of the `groupshared` array.
@@ -1080,7 +1091,7 @@ then the operation is a no-op.
 #### Matrix::Store
 
 ```c++
-template <uint Align = 16>
+template <uint Align>
 void Matrix::Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                    MatrixLayoutEnum Layout);
 
@@ -1119,7 +1130,8 @@ For the `Store` operations on `RWByteAddressBuffers`:
 
 For overloads operating on device memory (`RWByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
-be 16-byte aligned. The `Stride` argument must be a multiple of 16 bytes.
+be at least 4-byte aligned, but will default to a wider alignment for better
+performance. The `Stride` argument must be a multiple of 16 bytes.
 
 For the `Store` operations on `groupshared` arrays:
   - an element is a type matching the element type of the `groupshared` array,
@@ -1137,7 +1149,7 @@ explicit synchronization.
 ```c++
 
 // When Scope != Thread, the following overloads are available:
-template <uint Align = 16, MatrixUseEnum UseLocal = Use>
+template <uint Align, MatrixUseEnum UseLocal = Use>
 typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                          void>::type
 Matrix::InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
@@ -1190,7 +1202,9 @@ available for matrices with `MatrixUse::Accumulator` use. The
 
 For overloads operating on device memory (`RWByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
-be 64-byte aligned.
+be 128-byte aligned for `Thread`-scope matrices, and 4-byte aligned for `Wave`
+and `ThreadGroup` scope matrices. 16-byte alignment is recommended for `Wave`
+and `ThreadGroup` scope matrices for better performance.
 
 When accumulating to groupshared memory, a data conversion to the destination
 type following the [conversion rules](#data-conversion-rules) may occur if the
@@ -1261,6 +1275,9 @@ linalg::InterlockedAccumulate(RWByteAddressBuffer Res,
 Atomically adds the vector data of `Vec` to the `RWByteAddressBuffer` target
 `Res`. When accumulating to the `RWByteAddressBuffer` object, the accumulation
 addition is performed on the component type of the vector.
+
+The alignment of the target memory (base offset + `StartOffset`) must be at
+least 64-byte aligned.
 
 #### linalg::AccumulatorLayout()
 
@@ -1594,7 +1611,7 @@ Validation rules will enforce that:
 * `Stride` is `0` if the `Layout` is not `RowMajor` or `ColMajor`
 * If the matrix scope is `Thread` the resource handle must be an SRV
   ByteAddressBuffer
-* Alignment must be a multiple of 128 for thread-scope matrices, and 16 for all
+* Alignment must be a multiple of 128 for thread-scope matrices, and 4 for all
   other matrix scopes.
 
 ```llvm
@@ -1707,7 +1724,7 @@ Validation rules will enforce that:
 * `Layout` is `RowMajor` or `ColMajor`
 * The matrix scope must be `Wave` or `ThreadGroup`
 * The resource handle must be an UAV RWByteAddressBuffer
-* Alignment must be a multiple of 16
+* Alignment must be a multiple of 4
 
 ```llvm
 declare void @dx.op.linAlgMatrixStoreToMemory.[MatTy].[Ty](
@@ -1900,7 +1917,7 @@ Validation rules will enforce that:
 * `Stride` is `0` if the `Layout` is not `RowMajor` or `ColMajor`
 * The resource handle must be an UAV RWByteAddressBuffer
 * If scope is `Thread`, alignment must be a multiple of 128, otherwise it must
-  be a multiple of 16.
+  be a multiple of 4.
 
 ```llvm
 declare void @dx.op.linAlgMatrixAccumulateToMemory.[MatTy].[Ty](
@@ -2196,7 +2213,7 @@ template <typename T> struct is_packed_integral {
     static const bool value = true;                                            \
   };
 
-__PACKED_TYPE(uint8_t4_packed)
+__PACKED_TYPE(int8_t4_packed)
 __PACKED_TYPE(uint8_t4_packed)
 #endif // __hlsl_dx_compiler
 
@@ -2408,6 +2425,15 @@ struct ScalarCountFromPackedComponents {
       (PackedComponentCount + ElementsPerScalar - 1) / ElementsPerScalar;
 };
 
+template <ComponentEnum ElementType, SIZE_TYPE M, SIZE_TYPE N>
+struct DefaultAlign {
+  static const SIZE_TYPE MinDim = M < N ? M : N;
+  static const uint ElementAlign =
+      ScalarCountFromPackedComponents<ElementType, MinDim>::Value;
+  static const uint MinElementAlign = ElementAlign < 4 ? 4 : ElementAlign;
+  static const uint Value = MinElementAlign < 16 ? MinElementAlign : 16;
+};
+
 } // namespace __detail
 
 template <ComponentEnum ElementType, uint DimA> struct VectorRef {
@@ -2471,11 +2497,11 @@ class Matrix {
       typename hlsl::enable_if<hlsl::is_arithmetic<T>::value, Matrix>::type
       Splat(T Val);
 
-  template <uint Align = 16>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   static Matrix Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
                      MatrixLayoutEnum Layout);
 
-  template <uint Align = 16>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   static Matrix Load(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                      MatrixLayoutEnum Layout);
 
@@ -2509,7 +2535,7 @@ class Matrix {
                            void>::type
   Set(uint Index, ElementType Value);
 
-  template <uint Align = 16>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   void Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
              MatrixLayoutEnum Layout);
 
@@ -2524,7 +2550,8 @@ class Matrix {
         MatrixLayoutEnum Layout);
 
   // Accumulate methods
-  template <uint Align = 16, MatrixUseEnum UseLocal = Use>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value,
+            MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -995,8 +995,8 @@ For the `Load` operations on `[RW]ByteAddressBuffers`:
 For overloads operating on device memory (`[RW]ByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
 be 128-byte aligned for `Thread` scope matrices. For `Wave` and `ThreadGroup`
-scope matrices alignment must be at least 16. The `Stride` argument must
-refer to 16-byte aligned byte offsets.
+scope matrices alignment must be at least 16. The `Stride` argument must be a
+multiple of 16 bytes.
 
 For the `Load` operations on `groupshared` arrays:
   - an element is a type matching the element type of the `groupshared` array.
@@ -1119,8 +1119,7 @@ For the `Store` operations on `RWByteAddressBuffers`:
 
 For overloads operating on device memory (`RWByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
-be 16-byte aligned. The `Stride` argument must refer to 16-byte aligned byte
-offsets.
+be 16-byte aligned. The `Stride` argument must be a multiple of 16 bytes.
 
 For the `Store` operations on `groupshared` arrays:
   - an element is a type matching the element type of the `groupshared` array,
@@ -1622,8 +1621,8 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The offset value must be 16-byte aligned from the base offset, and the stride
-must be 16-byte aligned.
+The `Offset` must be 16-byte aligned, and `Stride` value must be a multiple of
+16 bytes.
 
 Validation rules will enforce that:
 * The output matrix scope must be `Wave` or `ThreadGroup`
@@ -1736,8 +1735,8 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The offset value must be 16-byte aligned from the base offset, and the stride
-must be 16-byte aligned.
+The `Offset` must be 16-byte aligned, and `Stride` value must be a multiple of
+16 bytes.
 
 Validation rules will enforce that:
 * The matrix scope must be `Wave` or `ThreadGroup`
@@ -1928,8 +1927,8 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The offset value must be 16-byte aligned from the base offset, and the stride
-must be 16-byte aligned.
+The `Offset` must be 16-byte aligned, and `Stride` value must be a multiple of
+16 bytes.
 
 Validation rules will enforce that:
 * The matrix scope must be `Wave` or `ThreadGroup`

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -999,7 +999,8 @@ supported.
 
 For the `Load` operations on `[RW]ByteAddressBuffers`:
   - the `Stride` argument is the row or column stride in bytes, and must be a
-    multiple of 16.
+    multiple of 16 for `Thread` scope matrices, or 4 for `Wave` or `ThreadGroup`
+    scope matrices.
   - the `Offset` argument is the number of bytes to skip before loading.
 
 For overloads operating on device memory (`[RW]ByteAddressBuffer`), the address of
@@ -1125,13 +1126,13 @@ No conversion is applied to the data.
 
 For the `Store` operations on `RWByteAddressBuffers`:
   - the `Stride` argument is the row or column stride in bytes, and must be a
-    multiple of 16.
+    multiple of 4.
   - the `Offset` argument is the number of bytes to skip before storing.
 
 For overloads operating on device memory (`RWByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
 be at least 4-byte aligned, but will default to a wider alignment for better
-performance. The `Stride` argument must be a multiple of 16 bytes.
+performance. The `Stride` argument must be a multiple of 4 bytes.
 
 For the `Store` operations on `groupshared` arrays:
   - an element is a type matching the element type of the `groupshared` array,
@@ -1638,8 +1639,9 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The `Offset` must be 16-byte aligned, and `Stride` value must be a multiple of
-16 bytes.
+The `Offset` must be 4-byte aligned, and `Stride` value must be a multiple of
+4 bytes. Performance may be better if the `Offset` is 16-byte aligned and
+`Stride` is a multiple of 16 bytes.
 
 Validation rules will enforce that:
 * The output matrix scope must be `Wave` or `ThreadGroup`
@@ -1752,8 +1754,9 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The `Offset` must be 16-byte aligned, and `Stride` value must be a multiple of
-16 bytes.
+The `Offset` must be 4-byte aligned, and `Stride` value must be a multiple of
+4 bytes. Performance may be better if the `Offset` is 16-byte aligned and
+`Stride` is a multiple of 16 bytes.
 
 Validation rules will enforce that:
 * The matrix scope must be `Wave` or `ThreadGroup`
@@ -1944,8 +1947,9 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The `Offset` must be 16-byte aligned, and `Stride` value must be a multiple of
-16 bytes.
+The `Offset` must be 4-byte aligned, and `Stride` value must be a multiple of
+4 bytes. Performance may be better if the `Offset` is 16-byte aligned and
+`Stride` is a multiple of 16 bytes.
 
 Validation rules will enforce that:
 * The matrix scope must be `Wave` or `ThreadGroup`

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -115,11 +115,11 @@ class Matrix {
       typename hlsl::enable_if<hlsl::is_arithmetic<T>::value, Matrix>::type
       Splat(T Val);
 
-  template <uint Align = 128>
+  template <uint Align = 16>
   static Matrix Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
                      MatrixLayoutEnum Layout);
 
-  template <uint Align = 128>
+  template <uint Align = 16>
   static Matrix Load(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                      MatrixLayoutEnum Layout);
 
@@ -153,7 +153,7 @@ class Matrix {
                            void>::type
   Set(uint Index, ElementType Value);
 
-  template <uint Align = 128>
+  template <uint Align = 16>
   void Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
              MatrixLayoutEnum Layout);
 
@@ -168,7 +168,7 @@ class Matrix {
         MatrixLayoutEnum Layout);
 
   // Accumulate methods
-  template <uint Align = 128, MatrixUseEnum UseLocal = Use>
+  template <uint Align = 16, MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
@@ -936,12 +936,12 @@ Matrix::Splat(WaveReadLaneFirst(Val));
 #### Matrix::Load
 
 ```c++
-template <uint Align = 128>
+template <uint Align> // defaults 128 on thread-scope, 16 on other scopes.
 static Matrix Matrix::Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
                            MatrixLayoutEnum Layout);
 
 // Not available on Thread scope matrices.
-template <uint Align = 128>
+template <uint Align = 16>
 static Matrix Matrix::Load(RWByteAddressBuffer Res, uint StartOffset,
                            uint Stride, MatrixLayoutEnum Layout);
 
@@ -992,10 +992,11 @@ For the `Load` operations on `[RW]ByteAddressBuffers`:
     multiple of 16.
   - the `Offset` argument is the number of bytes to skip before loading.
 
-For overloads operating on device memory (`RWByteAddressBuffer`), the address of
+For overloads operating on device memory (`[RW]ByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
-be 128-byte aligned. The `Stride` argument must refer to 16-byte aligned byte
-offsets.
+be 128-byte aligned for `Thread` scope matrices. For `Wave` and `ThreadGroup`
+scope matrices alignment must be at least 16. The `Stride` argument must
+refer to 16-byte aligned byte offsets.
 
 For the `Load` operations on `groupshared` arrays:
   - an element is a type matching the element type of the `groupshared` array.
@@ -1079,7 +1080,7 @@ then the operation is a no-op.
 #### Matrix::Store
 
 ```c++
-template <uint Align = 128>
+template <uint Align = 16>
 void Matrix::Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                    MatrixLayoutEnum Layout);
 
@@ -1118,7 +1119,7 @@ For the `Store` operations on `RWByteAddressBuffers`:
 
 For overloads operating on device memory (`RWByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
-be 128-byte aligned. The `Stride` argument must refer to 16-byte aligned byte
+be 16-byte aligned. The `Stride` argument must refer to 16-byte aligned byte
 offsets.
 
 For the `Store` operations on `groupshared` arrays:
@@ -1137,7 +1138,7 @@ explicit synchronization.
 ```c++
 
 // When Scope != Thread, the following overloads are available:
-template <uint Align = 128, MatrixUseEnum UseLocal = Use>
+template <uint Align = 16, MatrixUseEnum UseLocal = Use>
 typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                          void>::type
 Matrix::InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
@@ -1594,7 +1595,8 @@ Validation rules will enforce that:
 * `Stride` is `0` if the `Layout` is not `RowMajor` or `ColMajor`
 * If the matrix scope is `Thread` the resource handle must be an SRV
   ByteAddressBuffer
-* Alignment must be a multiple of 128
+* Alignment must be a multiple of 128 for thread-scope matrices, and 16 for all
+  other matrix scopes.
 
 ```llvm
 declare %dx.types.LinAlgMatrix<mangling> @dx.op.linAlgMatrixLoadFromMemory.[MatTy].[Ty](
@@ -1620,7 +1622,7 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The offset value must be 128-byte aligned from the base offset, and the stride
+The offset value must be 16-byte aligned from the base offset, and the stride
 must be 16-byte aligned.
 
 Validation rules will enforce that:
@@ -1706,7 +1708,7 @@ Validation rules will enforce that:
 * `Layout` is `RowMajor` or `ColMajor`
 * The matrix scope must be `Wave` or `ThreadGroup`
 * The resource handle must be an UAV RWByteAddressBuffer
-* Alignment must be a multiple of 128
+* Alignment must be a multiple of 16
 
 ```llvm
 declare void @dx.op.linAlgMatrixStoreToMemory.[MatTy].[Ty](
@@ -1734,7 +1736,7 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The offset value must be 128-byte aligned from the base offset, and the stride
+The offset value must be 16-byte aligned from the base offset, and the stride
 must be 16-byte aligned.
 
 Validation rules will enforce that:
@@ -1898,7 +1900,8 @@ Validation rules will enforce that:
   or `ThreadGroup`
 * `Stride` is `0` if the `Layout` is not `RowMajor` or `ColMajor`
 * The resource handle must be an UAV RWByteAddressBuffer
-* Alignment must be a multiple of 128
+* If scope is `Thread`, alignment must be a multiple of 128, otherwise it must
+  be a multiple of 16.
 
 ```llvm
 declare void @dx.op.linAlgMatrixAccumulateToMemory.[MatTy].[Ty](
@@ -1925,7 +1928,7 @@ parameters are the number of scalar elements of the scalar element type of the
 matrix. Meaning if the array is an i32 array, and the matrix is i8, the Offset
 and Stride are in terms of 8-bit elements.
 
-The offset value must be 128-byte aligned from the base offset, and the stride
+The offset value must be 16-byte aligned from the base offset, and the stride
 must be 16-byte aligned.
 
 Validation rules will enforce that:
@@ -2469,11 +2472,11 @@ class Matrix {
       typename hlsl::enable_if<hlsl::is_arithmetic<T>::value, Matrix>::type
       Splat(T Val);
 
-  template <uint Align = 128>
+  template <uint Align = 16>
   static Matrix Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
                      MatrixLayoutEnum Layout);
 
-  template <uint Align = 128>
+  template <uint Align = 16>
   static Matrix Load(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                      MatrixLayoutEnum Layout);
 
@@ -2507,7 +2510,7 @@ class Matrix {
                            void>::type
   Set(uint Index, ElementType Value);
 
-  template <uint Align = 128>
+  template <uint Align = 16>
   void Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
              MatrixLayoutEnum Layout);
 
@@ -2522,7 +2525,7 @@ class Matrix {
         MatrixLayoutEnum Layout);
 
   // Accumulate methods
-  template <uint Align = 128, MatrixUseEnum UseLocal = Use>
+  template <uint Align = 16, MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,


### PR DESCRIPTION
This relaxes the alignment requirements on wave and threadgroup scope matrices to 16-byte alignment.

In theory we might be able to go as low as 4 in some cases, but I kinda suspect that 16 is small enough and will give better performance.

Resolves #922