### PR TITLE
[0035] Fix accumulation to groupshared

### DIFF
--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1901,8 +1901,8 @@ match the scalar type or vector component type of the groupshared array. If the
 groupshared memory is `i32` or vector of _N_ by `i32` (`< N x i32 >`) the matrix
 may be of any type. Validation will verify this requirement.
 
-Matrix accumullation occurs in the data type of the matrix element with data in
-groupshared memory being treated as-if it were bitcast to the element type.
+Matrix accumulation occurs in the data type of the matrix element with data in
+groupshared memory being treated as if it were bitcast to the element type.
 
 For the Accumulate operation on groupshared arrays the `Offset` and `Stride`
 parameters are the number of scalar elements of the scalar element type of the

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -174,24 +174,21 @@ class Matrix {
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                         MatrixLayoutEnum Layout);
 
-  template <typename T, MatrixUseEnum UseLocal = Use,
-            MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
+  template <typename T, MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
   typename hlsl::enable_if<
       hlsl::is_arithmetic_vector<T>::value && Use == MatrixUse::Accumulator &&
-          UseLocal == Use && Scope == MatrixScope::Wave && ScopeLocal == Scope,
+          UseLocal == Use,
       void>::type
   InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx, uint Stride,
                         MatrixLayoutEnum Layout);
 
 #ifdef __hlsl_dx_compiler
   template <ComponentEnum TargetCompTy = ComponentTy, typename T,
-            MatrixUseEnum UseLocal = Use, MatrixScopeEnum ScopeLocal = Scope,
-            SIZE_TYPE Size>
+            MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
   typename hlsl::enable_if<
       hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
                     uint8_t4_packed>::value &&
-          Use == MatrixUse::Accumulator && UseLocal == Use &&
-          Scope == MatrixScope::Wave && ScopeLocal == Scope,
+          Use == MatrixUse::Accumulator && UseLocal == Use
       void>::type
   InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx, uint Stride,
                         MatrixLayoutEnum Layout);
@@ -1143,30 +1140,25 @@ typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
 Matrix::InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset,
                               uint Stride, MatrixLayoutEnum Layout);
 
-template <typename T, MatrixUseEnum UseLocal = Use,
-          MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
-typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                             Use == MatrixUse::Accumulator && UseLocal == Use &&
-                             (__detail::ScalarCountFromPackedComponents<
-                                  ComponentTy, M * N>::Value <= Size) &&
-                             Scope == MatrixScope::Wave && ScopeLocal == Scope,
-                         void>::type
+template <typename T, MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
+typename hlsl::enable_if<
+    hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
+                  ElementType>::value &&
+        hlsl::is_arithmetic_vector<T>::value && Use == MatrixUse::Accumulator &&
+        UseLocal == Use,
+    void>::type
 Matrix::InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx,
                               uint Stride, MatrixLayoutEnum Layout);
 
-template <ComponentEnum TargetCompTy = ComponentTy,
-          MatrixUseEnum UseLocal = Use, MatrixScopeEnum ScopeLocal = Scope,
-          SIZE_TYPE Size>
+template <ComponentEnum TargetCompTy = ComponentTy, typename T,
+          MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
 typename hlsl::enable_if<
-    !__detail::ComponentTypeTraits<TargetCompTy>::IsNativeScalar &&
-        Use == MatrixUse::Accumulator && UseLocal == Use &&
-        (__detail::ScalarCountFromPackedComponents<TargetCompTy,
-                                                   M * N>::Value <= Size) &&
-        Scope == MatrixScope::Wave && ScopeLocal == Scope,
+    hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
+                  uint8_t4_packed>::value &&
+        Use == MatrixUse::Accumulator && UseLocal == Use,
     void>::type
-Matrix::InterlockedAccumulate(groupshared uint8_t4_packed Arr[Size],
-                              uint StartIdx, uint Stride,
-                              MatrixLayoutEnum Layout);
+Matrix::InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx,
+                              uint Stride, MatrixLayoutEnum Layout);
 
 // When Scope == Thread, the following overload is available:
 template <uint Align = 128, MatrixUseEnum UseLocal = Use>
@@ -1192,21 +1184,11 @@ For overloads operating on device memory (`RWByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must
 be 64-byte aligned.
 
-When accumulating to groupshared memory, a data conversion to the destination
-type following the [conversion rules](#data-conversion-rules) may occur if the
-matrix component type does not match the groupshared memory target. If the
-accumulation is into a `uint8_t4_packed` array, the API requires specifying the
-interpretation type of the `groupshared` memory.
-
-> User beware: if you pass the wrong interpretation type to an accumulation to
-> `uint8_t4_packed` groupshared memory you'll likely get unexpected results!!!
+When accumulating to groupshared memory, the groupshared memory is interpreted
+as the data type of the matrix as if bit-cast.
 
 When accumulating to `RWByteAddressBuffer` objects, the accumulation is
-performed on the component type of the matrix object. When accumulating to
-`groupshared` memory, the matrix component data is converted to the target
-arithmetic or packed data type before atomic arithmetic is performed. No
-conversion is performed if the target arithmetic type matches the matrix
-component type.
+performed on the component type of the matrix object.
 
 #### Matrix::MultiplyAccumulate(Matrix, Matrix)
 
@@ -1905,7 +1887,6 @@ declare void @dx.op.linAlgMatrixAccumulateToMemory.[MatTy].[Ty](
   immarg i32,                         ; opcode
   %dx.types.LinAlgMatrix<mangling>,   ; matrix
   [Ty] addrspace(3)*,                 ; groupshared Ty[M * N]
-  immarg i32,                         ; target data type
   i32,                                ; Offset
   i32,                                ; Stride
   i32                                 ; matrix layout
@@ -1919,6 +1900,9 @@ any type other than `i32` or vector of `i32`, the matrix's component type must
 match the scalar type or vector component type of the groupshared array. If the
 groupshared memory is `i32` or vector of _N_ by `i32` (`< N x i32 >`) the matrix
 may be of any type. Validation will verify this requirement.
+
+Matrix accumullation occurs in the data type of the matrix element with data in
+groupshared memory being treated as-if it were bitcast to the element type.
 
 For the Accumulate operation on groupshared arrays the `Offset` and `Stride`
 parameters are the number of scalar elements of the scalar element type of the
@@ -2197,7 +2181,7 @@ template <typename T> struct is_packed_integral {
     static const bool value = true;                                            \
   };
 
-__PACKED_TYPE(uint8_t4_packed)
+__PACKED_TYPE(int8_t4_packed)
 __PACKED_TYPE(uint8_t4_packed)
 #endif // __hlsl_dx_compiler
 
@@ -2353,7 +2337,7 @@ template <typename T> struct TypeTraits {
       (ComponentEnum)dxil::ComponentType::Invalid;
 };
 
-template<> struct ComponentTypeTraits<ComponentType::BFloat16> {
+template <> struct ComponentTypeTraits<ComponentType::BFloat16> {
   using Type = uint;
   static const bool IsNativeScalar = false;
   static const uint ElementsPerScalar = 2;
@@ -2531,24 +2515,23 @@ class Matrix {
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
                         MatrixLayoutEnum Layout);
 
-  template <typename T, MatrixUseEnum UseLocal = Use,
-            MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
+  template <typename T, MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
   typename hlsl::enable_if<
-      hlsl::is_arithmetic_vector<T>::value && Use == MatrixUse::Accumulator &&
-          UseLocal == Use && Scope == MatrixScope::Wave && ScopeLocal == Scope,
+      hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
+                    ElementType>::value &&
+          hlsl::is_arithmetic_vector<T>::value &&
+          Use == MatrixUse::Accumulator && UseLocal == Use,
       void>::type
   InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx, uint Stride,
                         MatrixLayoutEnum Layout);
 
 #ifdef __hlsl_dx_compiler
   template <ComponentEnum TargetCompTy = ComponentTy, typename T,
-            MatrixUseEnum UseLocal = Use, MatrixScopeEnum ScopeLocal = Scope,
-            SIZE_TYPE Size>
+            MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
   typename hlsl::enable_if<
       hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
                     uint8_t4_packed>::value &&
-          Use == MatrixUse::Accumulator && UseLocal == Use &&
-          Scope == MatrixScope::Wave && ScopeLocal == Scope,
+          Use == MatrixUse::Accumulator && UseLocal == Use,
       void>::type
   InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx, uint Stride,
                         MatrixLayoutEnum Layout);

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1915,7 +1915,7 @@ must be 16-byte aligned.
 Validation rules will enforce that:
 * The matrix scope must be `Wave` or `ThreadGroup`
 * The groupshared array target must be big enough for the write
-* The target data type must match the groupshared array type, or the array must
+* The matrix element type must match the groupshared array type, or the array must
   be i32
 
 

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -192,8 +192,7 @@ class Matrix {
                         MatrixLayoutEnum Layout);
 
 #ifdef __hlsl_dx_compiler
-  template <ComponentEnum TargetCompTy = ComponentTy, typename T,
-            MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
+  template <typename T, MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
   typename hlsl::enable_if<
       hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
                     uint8_t4_packed>::value &&
@@ -1171,8 +1170,7 @@ typename hlsl::enable_if<
 Matrix::InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx,
                               uint Stride, MatrixLayoutEnum Layout);
 
-template <ComponentEnum TargetCompTy = ComponentTy, typename T,
-          MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
+template <typename T, MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
 typename hlsl::enable_if<
     hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
                   uint8_t4_packed>::value &&
@@ -2578,8 +2576,7 @@ class Matrix {
                         MatrixLayoutEnum Layout);
 
 #ifdef __hlsl_dx_compiler
-  template <ComponentEnum TargetCompTy = ComponentTy, typename T,
-            MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
+  template <typename T, MatrixUseEnum UseLocal = Use, SIZE_TYPE Size>
   typename hlsl::enable_if<
       hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
                     uint8_t4_packed>::value &&

--- a/proposals/0035-linalg-matrix.md
+++ b/proposals/0035-linalg-matrix.md
@@ -1197,7 +1197,7 @@ The matrix `InterlockedAccumulate` methods atomically add the matrix data to a
 target `RWByteAddressBuffer` or `groupshared` array. These methods are only
 available for matrices with `MatrixUse::Accumulator` use. The
 `RWByteAddressBuffer` overload is available for all matrix scopes, while the
-`groupshared` overload is only available for `Wave` scope matrices.
+`groupshared` overload is only available for `Wave` and `ThreadGroup` scope matrices.
 
 For overloads operating on device memory (`RWByteAddressBuffer`), the address of
 the first element of the matrix (base address of the resource + the offset) must


### PR DESCRIPTION
This corrects some errors I recently introduced to the spec and removes some undesirable complexitly.

When accumulating to groupshared memory we should effectively always treat the groupshared memory as if it is a blob of bytes of the matrix element type, and no data conversions are applied.

Fixes #925